### PR TITLE
[JENKINS-30412] Offering a sandbox-friendly RunWrapper.changeSets property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.5</version>
-        <relativePath />
+        <version>2.11</version>
+        <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-support</artifactId>
@@ -52,17 +52,18 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
+        <jenkins-test-harness.version>2.11</jenkins-test-harness.version>
     </properties>
     <dependencies>
         <dependency>
@@ -78,7 +79,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.16</version>
+            <version>1.21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
@@ -126,6 +127,26 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
             <version>1.15</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>2.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>2.5.0</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.1</version>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -28,10 +28,12 @@ import hudson.AbortException;
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.model.Run;
+import hudson.scm.ChangeLogSet;
 import hudson.security.ACL;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -175,6 +177,16 @@ public final class RunWrapper implements Serializable {
     @Whitelisted
     public @Nonnull String getAbsoluteUrl() throws AbortException {
         return build().getAbsoluteUrl();
+    }
+
+    @Whitelisted
+    public List<ChangeLogSet<? extends ChangeLogSet.Entry>> getChangeSets() throws Exception {
+        Run<?,?> build = build();
+        try { // TODO JENKINS-24141 should not need to use reflection here
+            return (List) build.getClass().getMethod("getChangeSets").invoke(build);
+        } catch (NoSuchMethodException x) {
+            return Collections.emptyList();
+        }
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -25,6 +25,10 @@
 package org.jenkinsci.plugins.workflow.support.steps.build;
 
 import hudson.model.Result;
+import java.util.regex.Pattern;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.SubstringMatcher;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -37,6 +41,7 @@ import org.junit.Rule;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 @Issue("JENKINS-26834")
@@ -44,6 +49,8 @@ public class RunWrapperTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    @Rule public GitSampleRepoRule sampleRepo1 = new GitSampleRepoRule();
+    @Rule public GitSampleRepoRule sampleRepo2 = new GitSampleRepoRule();
 
     @Test public void historyAndPickling() {
         r.addStep(new Statement() {
@@ -97,6 +104,60 @@ public class RunWrapperTest {
                 assertEquals("special", b1.getDisplayName());
             }
         });
+    }
+
+    @Issue("JENKINS-30412")
+    @Test public void getChangeSets() {
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                sampleRepo1.init();
+                sampleRepo2.init();
+                WorkflowJob p = r.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(
+                    "node {dir('1') {git($/" + sampleRepo1 + "/$)}; dir('2') {git($/" + sampleRepo2 + "/$)}}\n" +
+                    "echo(/changeSets: ${summarize currentBuild}/)\n" +
+                    "@NonCPS def summarize(b) {\n" +
+                    "  b.changeSets.collect {cs ->\n" +
+                    "    /kind=${cs.kind}; entries=/ + cs.collect {entry ->\n" +
+                    "      /${entry.commitId} by ${entry.author.id} ~ ${entry.author.fullName} on ${new Date(entry.timestamp)}: ${entry.msg}: / + entry.affectedFiles.collect {file ->\n" +
+                    "        /${file.editType.name} ${file.path}/\n" +
+                    "      }.join('; ')\n" +
+                    "    }.join(', ')\n" +
+                    "  }.join(' & ')\n" +
+                    "}", true));
+                r.j.assertLogContains("changeSets: ", r.j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+                sampleRepo1.write("onefile", "stuff");
+                sampleRepo1.git("add", "onefile");
+                sampleRepo1.git("commit", "--message=stuff");
+                assertThat(JenkinsRule.getLog(r.j.assertBuildStatusSuccess(p.scheduleBuild2(0))), containsRegexp(
+                    "changeSets: kind=git; entries=[a-f0-9]{40} by .+ ~ .+ on .+: stuff: add onefile"));
+                sampleRepo1.write("onefile", "more stuff");
+                sampleRepo1.write("anotherfile", "stuff");
+                sampleRepo1.git("add", "onefile", "anotherfile");
+                sampleRepo1.git("commit", "--message=more stuff");
+                sampleRepo1.write("onefile", "amended");
+                sampleRepo1.git("add", "onefile");
+                sampleRepo1.git("commit", "--message=amended");
+                sampleRepo2.write("elsewhere", "stuff");
+                sampleRepo2.git("add", "elsewhere");
+                sampleRepo2.git("commit", "--message=second repo");
+                assertThat(JenkinsRule.getLog(r.j.assertBuildStatusSuccess(p.scheduleBuild2(0))), containsRegexp(
+                    "changeSets: kind=git; entries=[a-f0-9]{40} by .+ ~ .+ on .+: more stuff: (edit onefile; add anotherfile|add anotherfile; edit onefile), " +
+                    "[a-f0-9]{40} by .+ ~ .+ on .+: amended: edit onefile & " +
+                    "kind=git; entries=[a-f0-9]{40} by .+ ~ .+ on .+: second repo: add elsewhere"));
+            }
+        });
+    }
+    // TODO why is this not in Hamcrest to begin with?
+    private static Matcher<String> containsRegexp(final String rx) {
+        return new SubstringMatcher(rx) {
+            @Override protected boolean evalSubstringOf(String string) {
+                return Pattern.compile(rx).matcher(string).find();
+            }
+            @Override protected String relationship() {
+                return "containing the regexp";
+            }
+        };
     }
 
 }


### PR DESCRIPTION
[JENKINS-30412](https://issues.jenkins-ci.org/browse/JENKINS-30412)

Downstream of https://github.com/jenkinsci/script-security-plugin/pull/78.

Also needs https://github.com/jenkinsci/pipeline-build-step-plugin/pull/4 for documentation; I struggled to find a way for `BuildTriggerStep/help-wait.html` and `RunWrapperBinder/help.jelly` to `st:include` some common file from `workflow-support`, but could not make it work. Specifiying just `path` throws an NPE from `IncludeTag`; you need to specify also `class`, but this is then not found since the class is in a plugin loader, not core. Not sure how [this](https://github.com/jenkinsci/groovy-postbuild-plugin/blob/9f49c9e128c6124fd01d44239565e5eb5388ba54/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/WorkflowManager/help.jelly#L28) works. Could probably switch to Groovy views and do it somehow. Anyway, a topic for a future refactoring.

@reviewbybees