### PR TITLE
[FIXED JENKINS-37366] Expose info about the project from currentBuild.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -145,7 +145,22 @@ public final class RunWrapper implements Serializable {
     public String getDisplayName() throws AbortException {
         return build().getDisplayName();
     }
-    
+
+    @Whitelisted
+    public String getFullDisplayName() throws AbortException {
+        return build().getFullDisplayName();
+    }
+
+    @Whitelisted
+    public String getProjectName() throws AbortException {
+        return build().getParent().getName();
+    }
+
+    @Whitelisted
+    public String getFullProjectName() throws AbortException {
+        return build().getParent().getFullName();
+    }
+
     @Whitelisted
     public @CheckForNull RunWrapper getPreviousBuild() throws AbortException {
         Run<?,?> previousBuild = build().getPreviousBuild();


### PR DESCRIPTION
[JENKINS-37366](https://issues.jenkins-ci.org/browse/JENKINS-37366)

More specifically, expose fullDisplayName, projectName and fullProjectName.

cc @reviewbybees esp @jglick 