### PR TITLE
Add duration info to pipeline steps (tree view) UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
@@ -5,10 +5,8 @@ import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
-import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
-import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.visualization.table.FlowNodeViewColumn;
 import org.jenkinsci.plugins.workflow.visualization.table.FlowNodeViewColumnDescriptor;
@@ -71,11 +69,11 @@ public class FlowGraphTable {
      */
     private Map<FlowNode, Row> createAllRows() {
         heads = execution.getCurrentHeads();
-        DepthFirstScanner scanner = new DepthFirstScanner();
+        final DepthFirstScanner scanner = new DepthFirstScanner();
         scanner.setup(heads);
 
         // nodes that we've visited
-        Map<FlowNode,Row> rows = new LinkedHashMap<FlowNode, Row>();
+        final Map<FlowNode,Row> rows = new LinkedHashMap<FlowNode, Row>();
 
         for (FlowNode n : scanner) {
             Row row = new Row(n);

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
@@ -219,7 +219,7 @@ public class FlowGraphTable {
                     newRow.durationMillis = System.currentTimeMillis()-newRow.startTimeMillis;
                 } else {
                     Row nextRow = newRow.firstGraphChild;
-                    if (newRow != null && nextRow.hasStartTime) {
+                    if (nextRow.hasStartTime) {
                         newRow.durationMillis = nextRow.startTimeMillis-newRow.startTimeMillis;
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
@@ -212,14 +212,14 @@ public class FlowGraphTable {
             }
         }
 
-        for (int i=0; i<rows.size()-1; i++) {
+        for (int i=0; i<rows.size(); i++) {
             Row newRow = rows.get(i);
             if (newRow.durationMillis == 0 && newRow.hasStartTime) {
                 if (newRow.node instanceof BlockStartNode && newRow.endNode == null) { // Block is running & incomplete
                     newRow.durationMillis = System.currentTimeMillis()-newRow.startTimeMillis;
                 } else {
-                    Row nextRow = rows.get(i+1);
-                    if (nextRow.hasStartTime) {
+                    Row nextRow = newRow.firstGraphChild;
+                    if (newRow != null && nextRow.hasStartTime) {
                         newRow.durationMillis = nextRow.startTimeMillis-newRow.startTimeMillis;
                     }
                 }
@@ -299,7 +299,7 @@ public class FlowGraphTable {
             }
         }
 
-        boolean isStart() {
+        public boolean isStart() {
             return node instanceof BlockStartNode;
         }
 
@@ -312,9 +312,9 @@ public class FlowGraphTable {
         }
 
         void addGraphChild(Row r) {
-            if (firstGraphChild ==null)
+            if (firstGraphChild ==null) {
                 firstGraphChild = r;
-            else {
+            } else {
                 firstGraphChild.addGraphSibling(r);
             }
         }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable/ajax.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable/ajax.jelly
@@ -45,9 +45,12 @@
             <!-- tooltip is for now debugging only -->
             <j:set var="exec_state" value=""/>
             <j:if test="${!row.executed}"><j:set var="exec_state" value=" (${%not executed})"/></j:if>
+            <j:set var="timeType" value="${row.isStart() ? 'in block' : 'in self'}"></j:set>
             <td style="padding-left: ${row.treeDepth*20+5}px" tooltip="ID: ${node.id}${exec_state}">
               <a href="${rootURL}/${node.url}">
-                ${row.displayName} <j:if test="${row.durationMillis > 0}"> - (${row.durationString})</j:if>
+                ${row.displayName}
+                <j:if test="${row.durationMillis > 0}"> - (${row.durationString} ${timeType})
+                </j:if>
               </a>
             </td>
             <j:forEach var="column" items="${columns}">

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable/ajax.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable/ajax.jelly
@@ -47,7 +47,7 @@
             <j:if test="${!row.executed}"><j:set var="exec_state" value=" (${%not executed})"/></j:if>
             <td style="padding-left: ${row.treeDepth*20+5}px" tooltip="ID: ${node.id}${exec_state}">
               <a href="${rootURL}/${node.url}">
-                ${row.displayName}
+                ${row.displayName} TESTING <j:if test="${row.duration > 0}">${row.duration}</j:if>
               </a>
             </td>
             <j:forEach var="column" items="${columns}">

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable/ajax.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable/ajax.jelly
@@ -47,7 +47,7 @@
             <j:if test="${!row.executed}"><j:set var="exec_state" value=" (${%not executed})"/></j:if>
             <td style="padding-left: ${row.treeDepth*20+5}px" tooltip="ID: ${node.id}${exec_state}">
               <a href="${rootURL}/${node.url}">
-                ${row.displayName} TESTING <j:if test="${row.duration > 0}">${row.duration}</j:if>
+                ${row.displayName} <j:if test="${row.durationMillis > 0}"> - (${row.durationString})</j:if>
               </a>
             </td>
             <j:forEach var="column" items="${columns}">


### PR DESCRIPTION
Adds timing info to tree view to help figure out what is taking time in a pipeline.  Spinoff from Jenkins world talks. 

- [x] Gets basic timing info for nodes
- [x] For blocks, they use the end node to compute total duration (yay!)
- [x] Handle cases where no start time is present
- [x] Provide a clean string formatting for elapsed time
- [x] Show if time is in the block or just the node self (cue for users on hoo to interpret)
- [x] Bugfix: figure out why last node or pair of nodes in a block is sometimes not getting timing info?

Manually tested with different (often complex) nesting structures, and with parallels.  Bug above is only one seen.  If no TimingAction is present on one of the flownodes (possible if there's a failure with loading actions), then no timing is shown for that one, rather than invalid info.