### PR TITLE
Use depthfirstscanner again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.4-SNAPSHOT</version> <!-- Snapshot until enforced ordering in DepthFirstScanner is released -->
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.2</version>
+            <version>2.4-SNAPSHOT</version> <!-- Snapshot until enforced ordering in DepthFirstScanner is released -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/visualization/table/FlowGraphTable.java
@@ -5,9 +5,9 @@ import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
-import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.visualization.table.FlowNodeViewColumn;
 import org.jenkinsci.plugins.workflow.visualization.table.FlowNodeViewColumnDescriptor;
 
@@ -69,14 +69,13 @@ public class FlowGraphTable {
      */
     private Map<FlowNode, Row> createAllRows() {
         heads = execution.getCurrentHeads();
-        // TODO switch to DepthFirstScanner when JENKINS-38458 is fixed, and put branches back in forward order
-        FlowGraphWalker walker = new FlowGraphWalker();
-        walker.addHeads(heads);
+        final DepthFirstScanner scanner = new DepthFirstScanner();
+        scanner.setup(heads);
 
         // nodes that we've visited
         final Map<FlowNode,Row> rows = new LinkedHashMap<FlowNode, Row>();
 
-        for (FlowNode n : walker) {
+        for (FlowNode n : scanner) {
             Row row = new Row(n);
             rows.put(n, row);
         }


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/16 now that the somewhat eccentric iteration order in FlowGraphWalker is maintained in DepthFirstScanner. 