### PR TITLE
Ensure that the SemaphoreStep always gets its TimingAction & test this

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/SemaphoreTimingActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/SemaphoreTimingActionTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.steps.build;
+
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class SemaphoreTimingActionTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Issue("JENKINS-38737")
+    @Test
+    public void testTimingAction() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "TimingTestJob");
+        job.setDefinition(new CpsFlowDefinition("semaphore 'wait'"));
+        WorkflowRun run  = job.scheduleBuild2(0).getStartCondition().get();
+        SemaphoreStep.waitForStart("wait/1", run);
+
+        FlowExecution exec = run.getExecution();
+        TimingAction ta = exec.getCurrentHeads().get(0).getAction(TimingAction.class);
+        Assert.assertNotNull(ta);
+
+        SemaphoreStep.success("wait/1", null);
+        jenkinsRule.waitForCompletion(run);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -37,10 +37,13 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -152,7 +155,14 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
 
         @Inject(optional=true) private SemaphoreStep step;
 
+        @StepContextParameter
+        private transient FlowNode node;
+
         @Override public boolean start() throws Exception {
+            // Because
+            if (node.getAction(TimingAction.class) == null) {
+                node.addAction(new TimingAction());
+            }
             State s = State.get();
             String k = step.k();
             boolean sync = true;


### PR DESCRIPTION
Solves [JENKINS-38737](https://issues.jenkins-ci.org/browse/JENKINS-38737). 

Possibly a bit hacky, but the step is only used for testing. 

@reviewbybees especially @jglick 