### PR TITLE
No messages printed from block-scoped steps after they invoked their bodies

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -34,13 +34,9 @@ import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
-import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -74,22 +70,7 @@ public abstract class DefaultStepContext extends StepContext {
             return value;
         } else if (key == TaskListener.class) {
             if (listener == null) {
-                final FlowNode node = getNode();
-                listener = LogActionImpl.stream(node, get(ConsoleLogFilter.class));
-                final AtomicReference<GraphListener> graphListener = new AtomicReference<GraphListener>();
-                graphListener.set(new GraphListener.Synchronous() {
-                    @Override public void onNewHead(FlowNode newNode) {
-                        try {
-                            if (!node.isRunning()) {
-                                getExecution().removeListener(graphListener.get());
-                                listener.getLogger().close();
-                            }
-                        } catch (IOException x) {
-                            Logger.getLogger(DefaultStepContext.class.getName()).log(Level.FINE, null, x);
-                        }
-                    }
-                });
-                getExecution().addListener(graphListener.get());
+                listener = LogActionImpl.stream(getNode(), get(ConsoleLogFilter.class));
             }
             return key.cast(listener);
         } else if (Node.class.isAssignableFrom(key)) {


### PR DESCRIPTION
Superseded by #15 but this is a far more conservative and localized change.

Background: in [JENKINS-34637](https://issues.jenkins-ci.org/browse/JENKINS-34637) I would like `TimeoutStepExecution` to print something to the build log when its body times out. Without this patch, that is impossible—the log message is discarded.

@reviewbybees