### PR TITLE
isRunning misbehaved on nodes inside parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
-        <relativePath />
+        <version>2.17</version>
+        <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-support</artifactId>
@@ -63,16 +63,15 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
-        <jenkins-test-harness.version>2.11</jenkins-test-harness.version>
     </properties>
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <version>2.5</version>
         </dependency>
@@ -87,9 +86,9 @@
             <version>1.4.9.Final</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -108,13 +107,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.1</version>
+            <version>1.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.9</version>
+            <version>2.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,19 +125,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.3</version>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>1.15</version>
+            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>1.15</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -149,7 +149,12 @@ public class LogActionImpl extends LogAction implements FlowNodeAction {
      */
     private static boolean isRunning(FlowNode node) {
         if (node instanceof BlockStartNode) {
-            return new LinearBlockHoppingScanner().findFirstMatch(node.getExecution().getCurrentHeads(), Predicates.equalTo(node)) != null;
+            for (FlowNode head : node.getExecution().getCurrentHeads()) {
+                if (new LinearBlockHoppingScanner().findFirstMatch(head, Predicates.equalTo(node)) != null) {
+                    return true;
+                }
+            }
+            return false;
         } else {
             return node.isRunning();
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImplTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.actions;
+
+import com.google.inject.Inject;
+import hudson.EnvVars;
+import hudson.model.TaskListener;
+import java.util.LinkedList;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class LogActionImplTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void logsAndBlocks() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("parallel a: {chatty('LBBL') {echo(/atom step in A with $remaining commands to go/)}}, b: {chatty('BL') {echo(/atom step in B with $remaining commands to go/)}}", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        r.assertLogContains("logging from LBBL with 3 commands to go", b);
+        r.assertLogContains("atom step in A with 2 commands to go", b);
+        r.assertLogContains("atom step in A with 1 commands to go", b);
+        r.assertLogContains("logging from LBBL with 0 commands to go", b);
+        r.assertLogContains("atom step in B with 1 commands to go", b);
+        /* TODO misuse of FlowNode.isRunning in WorkflowRun.copyLogs prevents this from appearing unless we access TaskListener from start(); should be fixed by JENKINS-38381:
+        r.assertLogContains("logging from BL with 0 commands to go", b);
+        */
+    }
+    public static class ChattyStep extends AbstractStepImpl {
+        public final String pattern;
+        @DataBoundConstructor public ChattyStep(String pattern) {this.pattern = pattern;}
+        @TestExtension("logsAndBlocks") public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+            public DescriptorImpl() {
+                super(Execution.class);
+            }
+            @Override public String getFunctionName() {return "chatty";}
+            @Override public boolean takesImplicitBlockArgument() {return true;}
+        }
+        public static class Execution extends AbstractStepExecutionImpl {
+            @Inject(optional=true) transient ChattyStep step;
+            String pattern;
+            LinkedList<Boolean> commands; // L ~ false to log, B ~ true to run block
+            @Override public boolean start() throws Exception {
+                commands = new LinkedList<>();
+                pattern = step.pattern;
+                for (char c : pattern.toCharArray()) {
+                    if (c == 'L') {
+                        commands.add(false);
+                    } else {
+                        assert c == 'B';
+                        commands.add(true);
+                    }
+                }
+                run();
+                return false;
+            }
+            private void run() throws Exception {
+                StepContext context = getContext();
+                if (commands.isEmpty()) {
+                    context.onSuccess(null);
+                } else if (commands.pop()) {
+                    context.newBodyInvoker().withCallback(new Callback()).withContext(new EnvVars("remaining", Integer.toString(commands.size()))).start();
+                } else {
+                    context.get(TaskListener.class).getLogger().println("logging from " + pattern + " with " + commands.size() + " commands to go");
+                    run();
+                }
+            }
+            @Override public void stop(Throwable cause) throws Exception {}
+            private final class Callback extends BodyExecutionCallback {
+                @Override public void onSuccess(StepContext context, Object result) {
+                    try {
+                        run();
+                    } catch (Exception x) {
+                        context.onFailure(x);
+                    }
+                }
+                @Override public void onFailure(StepContext context, Throwable t) {
+                    context.onFailure(t);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Regression from #19.

Without fix, would fail with

```
[test0 #1] java.lang.IllegalStateException: cannot start writing logs to a finished node org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode[id=9]
[test0 #1] 	at org.jenkinsci.plugins.workflow.support.actions.LogActionImpl.<init>(LogActionImpl.java:110)
[test0 #1] 	at org.jenkinsci.plugins.workflow.support.actions.LogActionImpl.stream(LogActionImpl.java:81)
[test0 #1] 	at org.jenkinsci.plugins.workflow.support.DefaultStepContext.get(DefaultStepContext.java:73)
[test0 #1] 	at org.jenkinsci.plugins.workflow.support.actions.LogActionImplTest$ChattyStep$Execution.run(LogActionImplTest.java:100)
[test0 #1] 	at org.jenkinsci.plugins.workflow.support.actions.LogActionImplTest$ChattyStep$Execution.access$100(LogActionImplTest.java:75)
[test0 #1] 	at org.jenkinsci.plugins.workflow.support.actions.LogActionImplTest$ChattyStep$Execution$Callback.onSuccess(LogActionImplTest.java:108)
[test0 #1] 	at …
```

Regarding #19, if you disable the assertion and just use `FlowNode.isRunning`, the test case would fail looking for

    logging from LBBL with 0 commands to go

@reviewbybees esp. @svanoort