### PR TITLE
Optimize river marshalling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/SingleTypedPickleFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/SingleTypedPickleFactory.java
@@ -50,4 +50,8 @@ public abstract class SingleTypedPickleFactory<T> extends PickleFactory {
         }
         return null;
     }
+
+    public Class<T> getPickleType() {
+        return this.type;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverWriter.java
@@ -206,7 +206,8 @@ public class RiverWriter implements Closeable {
                         return o;
                     }
                     Object maybeReplacement = cache.getFastReplacement(o, specialFactories);
-                    if (maybeReplacement != o && o instanceof Pickle) {
+
+                    if (maybeReplacement != o) {
                         pickles.add((Pickle)maybeReplacement);
                         return new DryCapsule(pickles.size() - 1); // let Pickle be serialized into the stream
                     }


### PR DESCRIPTION
*Should* reduce what profiling found was a significant hotspot -- calls to writeReplace which required a moderately expensive O(n) iteration over all PickleFactories to find one (or none) that apply.

How big a bottleneck?  In profiling with microbenchmark of running pipeline repeatedly, org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter$1.writeReplace(Object) RiverWriter.java took 117559 ms, out of 203537 for *all* calls to saveProgram.  

Almost all the runtime in that writeReplace is just iteration over the extensionlist.  Literally.

On its own, the writeReplace was ~1/5 of the total pipeline run time (jenkins.util.ContextResettingExecutorService$1.run() ContextResettingExecutorService.java took 545573 ms). 

TODO:
- [X] Trivial benchmark (scalability test in workflow-support) --> ugh, 1:30 to run vs. 1:11 before --> what's the culprit here?
- [x] Add type-limited interface for PickleFactory to workflow-api (better than just checking SingleTypedPickleFactory)
- [x] Use TypedPickleFactory for workflow-cps and workflow-support
- [x] In workflow-cps use the TypedPickleFactory
- [x] Move the PickleFactoryCache to workflow-api and use the TypedPickleFactory here, and then make it called PickleFactoryLookupCache ???
- [x] SingleTypeValuedPickle extends TypedPickleFactory
- [x] In workflow-cps ParamsVariable use the PickleCache (sigh)
- [x] Verify memory behavior won't cause leaks --> either key by class *name* (can't use memoizer then), or filter out groovy classes
- [ ] Rebenchmark it, and/or profile it.