### PR TITLE
Add getLog() to whitelist

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -162,6 +162,11 @@ public final class RunWrapper implements Serializable {
     }
 
     @Whitelisted
+    public List<String> getLog(int maxLines) throws IOException {
+        return build().getLog(maxLines);
+    }
+
+    @Whitelisted
     public @CheckForNull RunWrapper getPreviousBuild() throws AbortException {
         Run<?,?> previousBuild = build().getPreviousBuild();
         return previousBuild != null ? new RunWrapper(previousBuild, false) : null;

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -3,6 +3,7 @@
     <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>
     <dt><code>displayName</code></dt><dd>normally <code>#123</code> but sometimes set to, e.g., an SCM commit identifier</dd>
     <dt><code>description</code></dt><dd>additional information about the build</dd>
+    <dt><code>log</code></dt><dd>console output of the build</dd>
     <dt><code>id</code></dt><dd>normally <code>number</code> as a string</dd>
     <dt><code>timeInMillis</code></dt><dd>time since the epoch when the build was scheduled</dd>
     <dt><code>startTimeInMillis</code></dt><dd>time since the epoch when the build started running</dd>


### PR DESCRIPTION
It would be nice to get build logs without approving `method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild`, which is fairly permissive.