### PR TITLE
[FIXED JENKINS-42521] Add RunWrapper.getCurrentResult()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -128,6 +128,20 @@ public final class RunWrapper implements Serializable {
     }
 
     @Whitelisted
+    public boolean resultIsBetterOrEqualTo(String other) throws AbortException {
+        Result result = build().getResult() != null ? build().getResult() : Result.SUCCESS;
+        Result otherResult = Result.fromString(other);
+        return result.isBetterOrEqualTo(otherResult);
+    }
+
+    @Whitelisted
+    public boolean resultIsWorseOrEqualTo(String other) throws AbortException {
+        Result result = build().getResult() != null ? build().getResult() : Result.SUCCESS;
+        Result otherResult = Result.fromString(other);
+        return result.isWorseOrEqualTo(otherResult);
+    }
+
+    @Whitelisted
     public long getTimeInMillis() throws AbortException {
         return build().getTimeInMillis();
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -118,12 +118,6 @@ public final class RunWrapper implements Serializable {
     @Whitelisted
     public @CheckForNull String getResult() throws AbortException {
         Result result = build().getResult();
-        return result != null ? result.toString() : null;
-    }
-
-    @Whitelisted
-    public @Nonnull String getCurrentResult() throws AbortException {
-        Result result = build().getResult();
         return result != null ? result.toString() : Result.SUCCESS.toString();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -129,14 +129,20 @@ public final class RunWrapper implements Serializable {
 
     @Whitelisted
     public boolean resultIsBetterOrEqualTo(String other) throws AbortException {
-        Result result = build().getResult() != null ? build().getResult() : Result.SUCCESS;
+        Result result = build().getResult();
+        if (result == null) {
+            result = Result.SUCCESS;
+        }
         Result otherResult = Result.fromString(other);
         return result.isBetterOrEqualTo(otherResult);
     }
 
     @Whitelisted
     public boolean resultIsWorseOrEqualTo(String other) throws AbortException {
-        Result result = build().getResult() != null ? build().getResult() : Result.SUCCESS;
+        Result result = build().getResult();
+        if (result == null) {
+            result = Result.SUCCESS;
+        }
         Result otherResult = Result.fromString(other);
         return result.isWorseOrEqualTo(otherResult);
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -118,6 +118,12 @@ public final class RunWrapper implements Serializable {
     @Whitelisted
     public @CheckForNull String getResult() throws AbortException {
         Result result = build().getResult();
+        return result != null ? result.toString() : null;
+    }
+
+    @Whitelisted
+    public @Nonnull String getCurrentResult() throws AbortException {
+        Result result = build().getResult();
         return result != null ? result.toString() : Result.SUCCESS.toString();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -122,6 +122,12 @@ public final class RunWrapper implements Serializable {
     }
 
     @Whitelisted
+    public @Nonnull String getCurrentResult() throws AbortException {
+        Result result = build().getResult();
+        return result != null ? result.toString() : Result.SUCCESS.toString();
+    }
+
+    @Whitelisted
     public long getTimeInMillis() throws AbortException {
         return build().getTimeInMillis();
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -1,6 +1,6 @@
 <dl>
     <dt><code>number</code></dt><dd>build number (integer)</dd>
-    <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (will be <code>SUCCESS</code> for an ongoing build that has not otherwise had its status set)</dd>
+    <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>
     <dt><code>displayName</code></dt><dd>normally <code>#123</code> but sometimes set to, e.g., an SCM commit identifier</dd>
     <dt><code>description</code></dt><dd>additional information about the build</dd>
     <dt><code>id</code></dt><dd>normally <code>number</code> as a string</dd>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -1,6 +1,6 @@
 <dl>
     <dt><code>number</code></dt><dd>build number (integer)</dd>
-    <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>
+    <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (will be <code>SUCCESS</code> for an ongoing build that has not otherwise had its status set)</dd>
     <dt><code>displayName</code></dt><dd>normally <code>#123</code> but sometimes set to, e.g., an SCM commit identifier</dd>
     <dt><code>description</code></dt><dd>additional information about the build</dd>
     <dt><code>id</code></dt><dd>normally <code>number</code> as a string</dd>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -1,6 +1,9 @@
 <dl>
     <dt><code>number</code></dt><dd>build number (integer)</dd>
     <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>
+    <dt><code>currentResult</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code>. Will never be null.</dd>
+    <dt><code>resultIsBetterOrEqualTo(String)</code></dt><dd>Compares the current build result to the provided result string (<code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code>) and returns true if the current build result is better than or equal to the provided result.</dd>
+    <dt><code>resultIsWorseOrEqualTo(String)</code></dt><dd>Compares the current build result to the provided result string (<code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code>) and returns true if the current build result is worse than or equal to the provided result.</dd>
     <dt><code>displayName</code></dt><dd>normally <code>#123</code> but sometimes set to, e.g., an SCM commit identifier</dd>
     <dt><code>description</code></dt><dd>additional information about the build</dd>
     <dt><code>id</code></dt><dd>normally <code>number</code> as a string</dd>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -65,7 +65,7 @@ public class RunWrapperTest {
                     "}", true));
                 SemaphoreStep.success("basics/1", null);
                 WorkflowRun b1 = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-                r.j.assertLogContains("number=1 result=null", b1);
+                r.j.assertLogContains("number=1 result=SUCCESS", b1);
                 WorkflowRun b2 = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.success("basics/2", null);
                 SemaphoreStep.waitForStart("basics/3", b2);
@@ -167,19 +167,18 @@ public class RunWrapperTest {
     }
 
     @Issue("JENKINS-37366")
-    @Test public void getCurrentResult() {
+    @Test public void getResultDefault() {
         r.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                MockFolder folder = r.j.createFolder("this-folder");
-                WorkflowJob p = folder.createProject(WorkflowJob.class, "current-result-job");
+                WorkflowJob p = r.j.createProject(WorkflowJob.class, "default-result-job");
                 p.setDefinition(new CpsFlowDefinition(
-                        "echo \"initial currentBuild.currentResult='${currentBuild.currentResult}'\"\n" +
+                        "echo \"initial currentBuild.result='${currentBuild.result}'\"\n" +
                         "currentBuild.result = 'UNSTABLE'\n" +
-                        "echo \"final currentBuild.currentResult='${currentBuild.currentResult}'\"\n",
+                        "echo \"final currentBuild.result='${currentBuild.result}'\"\n",
                         true));
                 WorkflowRun b = r.j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
-                r.j.assertLogContains("initial currentBuild.currentResult='" + Result.SUCCESS.toString() + "'", b);
-                r.j.assertLogContains("final currentBuild.currentResult='" + Result.UNSTABLE.toString() + "'", b);
+                r.j.assertLogContains("initial currentBuild.result='" + Result.SUCCESS.toString() + "'", b);
+                r.j.assertLogContains("final currentBuild.result='" + Result.UNSTABLE.toString() + "'", b);
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -175,11 +175,15 @@ public class RunWrapperTest {
                 p.setDefinition(new CpsFlowDefinition(
                         "echo \"initial currentBuild.currentResult='${currentBuild.currentResult}'\"\n" +
                         "currentBuild.result = 'UNSTABLE'\n" +
-                        "echo \"final currentBuild.currentResult='${currentBuild.currentResult}'\"\n",
+                        "echo \"final currentBuild.currentResult='${currentBuild.currentResult}'\"\n" +
+                        "echo \"resultIsBetterOrEqualTo FAILURE: ${currentBuild.resultIsBetterOrEqualTo('FAILURE')}\"\n" +
+                        "echo \"resultIsWorseOrEqualTo SUCCESS: ${currentBuild.resultIsWorseOrEqualTo('SUCCESS')}\"\n",
                         true));
                 WorkflowRun b = r.j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
                 r.j.assertLogContains("initial currentBuild.currentResult='" + Result.SUCCESS.toString() + "'", b);
                 r.j.assertLogContains("final currentBuild.currentResult='" + Result.UNSTABLE.toString() + "'", b);
+                r.j.assertLogContains("resultIsBetterOrEqualTo FAILURE: true", b);
+                r.j.assertLogContains("resultIsWorseOrEqualTo SUCCESS: true", b);
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -65,11 +65,11 @@ public class RunWrapperTest {
                     "}", true));
                 SemaphoreStep.success("basics/1", null);
                 WorkflowRun b1 = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-                r.j.assertLogContains("number=1 result=SUCCESS", b1);
+                r.j.assertLogContains("number=1 result=null", b1);
                 WorkflowRun b2 = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.success("basics/2", null);
                 SemaphoreStep.waitForStart("basics/3", b2);
-                r.j.waitForMessage("number=2 result=SUCCESS", b2);
+                r.j.waitForMessage("number=2 result=null", b2);
                 r.j.assertLogNotContains("number=1", b2);
             }
         });
@@ -167,18 +167,19 @@ public class RunWrapperTest {
     }
 
     @Issue("JENKINS-37366")
-    @Test public void getResultDefault() {
+    @Test public void getCurrentResult() {
         r.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.createProject(WorkflowJob.class, "default-result-job");
+                MockFolder folder = r.j.createFolder("this-folder");
+                WorkflowJob p = folder.createProject(WorkflowJob.class, "current-result-job");
                 p.setDefinition(new CpsFlowDefinition(
-                        "echo \"initial currentBuild.result='${currentBuild.result}'\"\n" +
+                        "echo \"initial currentBuild.currentResult='${currentBuild.currentResult}'\"\n" +
                         "currentBuild.result = 'UNSTABLE'\n" +
-                        "echo \"final currentBuild.result='${currentBuild.result}'\"\n",
+                        "echo \"final currentBuild.currentResult='${currentBuild.currentResult}'\"\n",
                         true));
                 WorkflowRun b = r.j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
-                r.j.assertLogContains("initial currentBuild.result='" + Result.SUCCESS.toString() + "'", b);
-                r.j.assertLogContains("final currentBuild.result='" + Result.UNSTABLE.toString() + "'", b);
+                r.j.assertLogContains("initial currentBuild.currentResult='" + Result.SUCCESS.toString() + "'", b);
+                r.j.assertLogContains("final currentBuild.currentResult='" + Result.UNSTABLE.toString() + "'", b);
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -166,6 +166,24 @@ public class RunWrapperTest {
         });
     }
 
+    @Issue("JENKINS-37366")
+    @Test public void getCurrentResult() {
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                MockFolder folder = r.j.createFolder("this-folder");
+                WorkflowJob p = folder.createProject(WorkflowJob.class, "current-result-job");
+                p.setDefinition(new CpsFlowDefinition(
+                        "echo \"initial currentBuild.currentResult='${currentBuild.currentResult}'\"\n" +
+                        "currentBuild.result = 'UNSTABLE'\n" +
+                        "echo \"final currentBuild.currentResult='${currentBuild.currentResult}'\"\n",
+                        true));
+                WorkflowRun b = r.j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+                r.j.assertLogContains("initial currentBuild.currentResult='" + Result.SUCCESS.toString() + "'", b);
+                r.j.assertLogContains("final currentBuild.currentResult='" + Result.UNSTABLE.toString() + "'", b);
+            }
+        });
+    }
+
     // Like org.hamcrest.text.MatchesPattern.matchesPattern(String) but doing a substring, not whole-string, match:
     private static Matcher<String> containsRegexp(final String rx) {
         return new SubstringMatcher(rx) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -69,7 +69,7 @@ public class RunWrapperTest {
                 WorkflowRun b2 = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.success("basics/2", null);
                 SemaphoreStep.waitForStart("basics/3", b2);
-                r.j.waitForMessage("number=2 result=null", b2);
+                r.j.waitForMessage("number=2 result=SUCCESS", b2);
                 r.j.assertLogNotContains("number=1", b2);
             }
         });


### PR DESCRIPTION
[JENKINS-42521](https://issues.jenkins-ci.org/browse/JENKINS-42521)

getCurrentResult() will never be null - if build().getResult() is
null, it'll return Result.SUCCESS.toString(). In a perfect world, I'd
change RunWrapper.getResult() to this behavior, but that'd possibly
break existing logic out in the wild, so a new method it is.

cc @reviewbybees esp @jglick @rsandell @batmat @svanoort 