### PR TITLE
[FIXED JENKINS-42952] Make currentBuild.duration meaningful

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -133,7 +133,12 @@ public final class RunWrapper implements Serializable {
 
     @Whitelisted
     public long getDuration() throws AbortException {
-	 return build().getDuration();
+	 return System.currentTimeMillis() - build().getStartTimeInMillis();
+    }
+
+    @Whitelisted
+    public String getDurationString() throws AbortException {
+        return build().getDurationString();
     }
 
     @Whitelisted

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -133,7 +133,7 @@ public final class RunWrapper implements Serializable {
 
     @Whitelisted
     public long getDuration() throws AbortException {
-	 return System.currentTimeMillis() - build().getStartTimeInMillis();
+	 return build().getDuration() != 0 ? build().getDuration() : System.currentTimeMillis() - build().getStartTimeInMillis();
     }
 
     @Whitelisted

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -7,6 +7,7 @@
     <dt><code>timeInMillis</code></dt><dd>time since the epoch when the build was scheduled</dd>
     <dt><code>startTimeInMillis</code></dt><dd>time since the epoch when the build started running</dd>
     <dt><code>duration</code></dt><dd>duration of the build in milliseconds</dd>
+    <dt><code>durationString</code></dt><dd>a human-readable representation of the build duration</dd>
     <dt><code>previousBuild</code></dt><dd>another similar object, or null</dd>
     <dt><code>nextBuild</code></dt><dd>similarly</dd>
     <dt><code>absoluteUrl</code></dt><dd>URL of build index page</dd>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.support.steps.build;
 
+import hudson.model.Messages;
 import hudson.model.Result;
 import java.util.regex.Pattern;
 import jenkins.plugins.git.GitSampleRepoRule;
@@ -162,6 +163,21 @@ public class RunWrapperTest {
                 r.j.assertLogContains("currentBuild.fullDisplayName='this-folder » this-job #1'", b);
                 r.j.assertLogContains("currentBuild.projectName='this-job'", b);
                 r.j.assertLogContains("currentBuild.fullProjectName='this-folder/this-job'", b);
+            }
+        });
+    }
+
+    @Issue("JENKINS-42952")
+    @Test public void duration() {
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = r.j.createProject(WorkflowJob.class, "this-job");
+                p.setDefinition(new CpsFlowDefinition(
+                        "echo \"currentBuild.duration='${currentBuild.duration}'\"\n" +
+                                "echo \"currentBuild.durationString='${currentBuild.durationString}'\"\n", true));
+                WorkflowRun b = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+                r.j.assertLogNotContains("currentBuild.duration='0'", b);
+                r.j.assertLogNotContains("currentBuild.durationString='" + Messages.Run_NotStartedYet() + "'", b);
             }
         });
     }


### PR DESCRIPTION
[JENKINS-42952](https://issues.jenkins-ci.org/browse/JENKINS-42952)

...and add currentBuild.durationString.

cc @reviewbybees esp @jglick 