### PR TITLE
[JENKINS-40934] Avoid redundant scans of parallels

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -152,13 +152,16 @@ public class LogActionImpl extends LogAction implements FlowNodeAction {
      * (for example by calling {@link StepContext#get} on demand rather than by using {@link StepContextParameter}).
      */
     private static boolean isRunning(FlowNode node) {
+        if (node.isRunning()) {
+            return true;
+        }
         if (node instanceof BlockStartNode) {
             // Block start is considered running if currently executing nodes are part of the block
             List<FlowNode> headNodes = node.getExecution().getCurrentHeads();
             AbstractFlowScanner scanner = (headNodes.size() > 1) ? new DepthFirstScanner() : new LinearBlockHoppingScanner();
-            return (scanner.findFirstMatch(headNodes, Predicates.equalTo(node)) != null) ? true : false;
+            return scanner.findFirstMatch(headNodes, Predicates.equalTo(node)) != null;
         } else {
-            return node.isRunning();
+            return false;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -39,6 +39,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,8 +52,10 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.AbstractFlowScanner;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner;
+import org.jenkinsci.plugins.workflow.graphanalysis.LinearScanner;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.accmod.Restricted;
@@ -151,8 +154,9 @@ public class LogActionImpl extends LogAction implements FlowNodeAction {
     private static boolean isRunning(FlowNode node) {
         if (node instanceof BlockStartNode) {
             // Block start is considered running if currently executing nodes are part of the block
-            DepthFirstScanner scanner = new DepthFirstScanner();
-            return (scanner.findFirstMatch(node.getExecution().getCurrentHeads(), Predicates.equalTo(node)) != null) ? true : false;
+            List<FlowNode> headNodes = node.getExecution().getCurrentHeads();
+            AbstractFlowScanner scanner = (headNodes.size() > 1) ? new DepthFirstScanner() : new LinearScanner();
+            return (scanner.findFirstMatch(headNodes, Predicates.equalTo(node)) != null) ? true : false;
         } else {
             return node.isRunning();
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -155,7 +155,7 @@ public class LogActionImpl extends LogAction implements FlowNodeAction {
         if (node instanceof BlockStartNode) {
             // Block start is considered running if currently executing nodes are part of the block
             List<FlowNode> headNodes = node.getExecution().getCurrentHeads();
-            AbstractFlowScanner scanner = (headNodes.size() > 1) ? new DepthFirstScanner() : new LinearScanner();
+            AbstractFlowScanner scanner = (headNodes.size() > 1) ? new DepthFirstScanner() : new LinearBlockHoppingScanner();
             return (scanner.findFirstMatch(headNodes, Predicates.equalTo(node)) != null) ? true : false;
         } else {
             return node.isRunning();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -51,6 +51,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
@@ -149,12 +150,9 @@ public class LogActionImpl extends LogAction implements FlowNodeAction {
      */
     private static boolean isRunning(FlowNode node) {
         if (node instanceof BlockStartNode) {
-            for (FlowNode head : node.getExecution().getCurrentHeads()) {
-                if (new LinearBlockHoppingScanner().findFirstMatch(head, Predicates.equalTo(node)) != null) {
-                    return true;
-                }
-            }
-            return false;
+            // Block start is considered running if currently executing nodes are part of the block
+            DepthFirstScanner scanner = new DepthFirstScanner();
+            return (scanner.findFirstMatch(node.getExecution().getCurrentHeads(), Predicates.equalTo(node)) != null) ? true : false;
         } else {
             return node.isRunning();
         }


### PR DESCRIPTION
[JENKINS-40934](https://issues.jenkins-ci.org/browse/JENKINS-40934)

Pretty straightforward fast fix here -- we could avoid a lot of this nonsense if our flows kept an easy trace of enclosing blocks in the context, but that's a much bigger change to make.

@reviewbybees 