### PR TITLE
[JENKINS-26137] Integrate a patched version of JBoss Marshalling with better diagnostics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.25</version>
+        <version>2.30</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
-            <version>1.4.9.Final</version> <!-- TODO JENKINS-32986 need 1.4.12.Final when released to pick up JBMAR-189 https://github.com/jboss-remoting/jboss-marshalling/pull/48 -->
+            <version>1.4.12.jenkins-3</version> <!-- https://github.com/jglick/jboss-marshalling/compare/1.4.12.Final...1.4.12.jenkins-3 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverWriterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverWriterTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.pickles.serialization;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import hudson.Functions;
+import java.io.File;
+import java.io.NotSerializableException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import static org.hamcrest.Matchers.containsString;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.pickles.PickleFactory;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+
+public class RiverWriterTest {
+
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test public void trivial() throws Exception {
+        File f = tmp.newFile();
+        FlowExecutionOwner owner = FlowExecutionOwner.dummyOwner();
+        try (RiverWriter w = new RiverWriter(f, owner, Collections.<PickleFactory>emptySet())) {
+            w.writeObject(Collections.singletonList("hello world"));
+        }
+        Object o;
+        try (RiverReader r = new RiverReader(f, RiverWriterTest.class.getClassLoader(), owner)) {
+            o = r.restorePickles(new ArrayList<ListenableFuture<?>>()).get().readObject();
+        }
+        assertEquals(Collections.singletonList("hello world"), o);
+    }
+
+    @Issue("JENKINS-26137")
+    @Test public void errors() throws Exception {
+        File f = tmp.newFile();
+        FlowExecutionOwner owner = FlowExecutionOwner.dummyOwner();
+        try (RiverWriter w = new RiverWriter(f, owner, Collections.<PickleFactory>emptySet())) {
+            w.writeObject(Collections.singletonList(new NotActuallySerializable()));
+            fail();
+        } catch (NotSerializableException x) {
+            /*
+            original:
+            Caused by: an exception which occurred:
+                in field bad
+                in object java.util.Collections$SingletonList@7791a8b4
+            now:
+            Caused by: an exception which occurred:
+                in field org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReaderTest$NotActuallySerializable.bad
+                in object org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReaderTest$NotActuallySerializable@6b09bb57
+                in object java.util.Collections$SingletonList@6b09bb76
+            */
+            assertThat(Functions.printThrowable(x), containsString(NotActuallySerializable.class.getName() + ".bad"));
+        }
+    }
+    private static class NotActuallySerializable implements Serializable {
+        String good = "OK";
+        Object bad = new Object();
+    }
+
+    // TODO pickle resolution
+
+}


### PR DESCRIPTION
[JENKINS-26137](https://issues.jenkins-ci.org/browse/JENKINS-26137): picks up https://github.com/jboss-remoting/jboss-marshalling/pull/37 which remains unevaluated.

Also related to [JENKINS-32986](https://issues.jenkins-ci.org/browse/JENKINS-32986), picks up https://github.com/jboss-remoting/jboss-marshalling/pull/48 which is in `1.4.12.Final` but that did not make it to Central.

@reviewbybees