### PR TITLE
Switch to POM properties for Pipeline dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
         <git-plugin.version>3.0.5</git-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
         <workflow-step-api-plugin.version>2.10</workflow-step-api-plugin.version>
+        <workflow-api.version>2.15</workflow-api.version>
+        <script-security.version>1.26</script-security.version>
+        <structs.version>1.6</structs.version>
+        <workflow-cps.version>2.28</workflow-cps.version>
+        <workflow-durable-task-step.version>2.9</workflow-durable-task-step.version>
+        <workflow-job.version>2.10</workflow-job.version>
+        <workflow-basic-steps.version>2.4</workflow-basic-steps.version>
     </properties>
     <dependencies>
         <dependency>
@@ -77,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.15</version>
+            <version>${workflow-api.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -88,7 +95,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.26</version>
+            <version>${script-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
@@ -117,13 +124,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.6</version>
+            <version>${structs.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.28</version>
+            <version>${workflow-cps.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -141,19 +148,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.9</version>
+            <version>${workflow-durable-task-step.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.10</version>
+            <version>${workflow-job.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.4</version>
+            <version>${workflow-basic-steps.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I'm working on tooling to do testing of core + groovy-sandbox +
groovy-cps + workflow-cps + script-security + the rest of the main
Pipeline plugins against bleeding-edge versions of each other and
different versions of Groovy. To do this, it'd be a lot easier if the
dependencies between the various things I'm building/testing had their
versions controlled by properties.

cc @reviewbybees 