### PR TITLE
Allow FlowNodeStorage to support in-memory Flownodes with deferred writing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-support</artifactId>
-    <version>2.15-SNAPSHOT</version>
+    <version>2.15-deferactionwrite-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Supporting APIs</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Supporting+APIs+Plugin</url>
@@ -66,18 +66,18 @@
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.0.5</git-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
-        <workflow-step-api-plugin.version>2.10</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
+            <version>2.13-deferactionwrite-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.21-20170818.152216-3</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/45 -->
+            <version>2.21-deferactionwrite-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/45 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,11 @@
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.0.5</git-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
-        <workflow-step-api-plugin.version>2.13-deferactionwrite-SNAPSHOT</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.13-deferactionwrite2-20170901.210414-1</workflow-step-api-plugin.version>
     </properties>
     <dependencies>
         <dependency>
+            <!-- Temp version until https://github.com/jenkinsci/workflow-step-api-plugin/pull/29 gets released  -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>${workflow-step-api-plugin.version}</version>
@@ -77,7 +78,8 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.21-deferactionwrite-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/45 -->
+            <!-- Temp version for https://github.com/jenkinsci/workflow-api-plugin/pull/49 -->
+            <version>2.21-deferactionwrite-20170901.212705-1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,13 @@
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.0.5</git-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
-        <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.13-deferactionwrite-SNAPSHOT</workflow-step-api-plugin.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.13-deferactionwrite-SNAPSHOT</version>
+            <version>${workflow-step-api-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -61,7 +61,7 @@ public abstract class DefaultStepContext extends StepContext {
         T value = doGet(key);
         if (key == EnvVars.class) {
             Run<?,?> run = get(Run.class);
-            EnvironmentAction a = run.getAction(EnvironmentAction.class);
+            EnvironmentAction a = run == null ? null : run.getAction(EnvironmentAction.class);
             EnvVars customEnvironment = a != null ? a.getEnvironment() : run.getEnvironment(get(TaskListener.class));
             return key.cast(EnvironmentExpander.getEffectiveEnvironment(customEnvironment, (EnvVars) value, get(EnvironmentExpander.class)));
         } else if (key == Launcher.class) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -46,6 +46,7 @@ import javax.annotation.Nonnull;
 import org.apache.commons.jelly.XMLOutput;
 import org.jenkinsci.plugins.workflow.actions.FlowNodeAction;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
+import org.jenkinsci.plugins.workflow.actions.PersistentAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -58,7 +59,7 @@ import org.kohsuke.stapler.framework.io.ByteBuffer;
  *
  * @author Kohsuke Kawaguchi
  */
-public class LogActionImpl extends LogAction implements FlowNodeAction {
+public class LogActionImpl extends LogAction implements FlowNodeAction, PersistentAction {
 
     private static final Logger LOGGER = Logger.getLogger(LogActionImpl.class.getName());
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/storage/FlowNodeStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/storage/FlowNodeStorage.java
@@ -50,4 +50,9 @@ public abstract class FlowNodeStorage implements FlowActionStorage {
      */
     public abstract @CheckForNull FlowNode getNode(String id) throws IOException;
     public abstract void storeNode(FlowNode n) throws IOException;
+
+    /** Invoke this to assure any unwritten {@link FlowNode} data is persisted to disk */
+    public void persistAll() throws IOException {
+        // Only needs implementation if you're not already guaranteeing persistence at all times
+    }
 }


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/49

Upstream of some major performance optimizations that reduce redundant serialization calls by waiting until a FlowNode has its basic set of actions before persisting the whole thing. 

Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/49

TODO:
- [ ] Additional test coverage of revised storage engine (needed here, to explicitly exercise new logic even if the test version of workflow-cps doesn't include these goodies)

Deployed snapshot as:
```
<dependency>
            <groupId>org.jenkins-ci.plugins.workflow</groupId>
            <artifactId>workflow-support</artifactId>
            <version>2.15-deferactionwrite-20170915.012921-2-</version>
        </dependency>
```