### PR TITLE
Make Timeout repeatedly interrupt a stuck thread, and note that this is happening

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -36,7 +36,7 @@
     <version>2.17-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Supporting APIs</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Supporting+APIs+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Supporting+APIs+Plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>
@@ -63,6 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>2.60.2</jenkins.version>
+        <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.0.5</git-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>


### PR DESCRIPTION
Saw a support bundle that showed a thread inside

```
"jenkins.util.Timer [#3] / waiting for JNLP4-connect connection from …" …
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
    at java.lang.Object.wait(Native Method)
    at hudson.remoting.Request.call(Request.java:165)
    - locked <0x…> (a hudson.remoting.UserRequest)
    at hudson.remoting.Channel.call(Channel.java:903)
    at hudson.FilePath.act(FilePath.java:987)
    at hudson.FilePath.act(FilePath.java:976)
    at hudson.FilePath.deleteRecursive(FilePath.java:1178)
    at org.jenkinsci.plugins.durabletask.FileMonitoringTask$FileMonitoringController.cleanup(FileMonitoringTask.java:187)
    at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.check(DurableTaskStep.java:326)
    at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution.run(DurableTaskStep.java:279)
    at …
```

From that it was unclear whether this one call to `FilePath.deleteRecursive` was in fact taking more than the 10s allotted, or if there were lots of repeated calls to `run`/`check`, or what. This patch

* Ensures that even if some code swallows `InterruptedException`, a new signal will be sent.
* Makes sure something appears in the system log when a thread is blowing past its timeout.

I tried to also set the thread name to indicate how stalled it is, to allow this information to appear in thread dumps, but could not get it to work—whether due to a JVM bug or some oversight on my part, I am not sure.

@reviewbybees