### PR TITLE
Ensure that regardless of where Timeout is first used, its executor has the correct classloader on the Thread

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Timeout.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Timeout.java
@@ -44,7 +44,16 @@ public class Timeout implements AutoCloseable {
 
     private static final Logger LOGGER = Logger.getLogger(Timeout.class.getName());
 
-    private static final ScheduledExecutorService interruptions = Executors.newSingleThreadScheduledExecutor(new NamingThreadFactory(new DaemonThreadFactory(), "Timeout.interruptions"));
+    static class ClassloaderSanityDaemonThreadFactory extends DaemonThreadFactory {
+        public Thread newThread(Runnable r) {
+            Thread t = super.newThread(r);
+            t.setContextClassLoader(Timeout.class.getClassLoader());
+            return t;
+        }
+    }
+
+
+    private static final ScheduledExecutorService interruptions = Executors.newSingleThreadScheduledExecutor(new NamingThreadFactory(new ClassloaderSanityDaemonThreadFactory(), "Timeout.interruptions"));
 
     private final Thread thread;
     private volatile boolean completed;


### PR DESCRIPTION
Fixes a minor but obnoxious bug where the Timeout utility is first invoked from inside Pipeline CpsThread and gets the wrong classloader... which means a leaky GroovyClassloader.

@reviewbybees 