### PR TITLE
[JEP-206] Always use UTF-8 for per-step log files

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-4</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.12</version>
+        <version>3.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-support</artifactId>
-    <version>2.20-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Supporting APIs</name>
     <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Supporting+APIs+Plugin</url>
@@ -62,7 +62,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <revision>2.19</revision>
+        <revision>2.20</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.62</jenkins.version>
         <java.level>8</java.level>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -38,6 +38,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -73,15 +74,14 @@ public class LogActionImpl extends LogAction implements FlowNodeAction, Persiste
     public static @Nonnull TaskListener stream(final @Nonnull FlowNode node, @CheckForNull ConsoleLogFilter filter) throws IOException, InterruptedException {
         LogActionImpl la = node.getAction(LogActionImpl.class);
         if (la == null) {
-            // TODO: use UTF-8
-            la = new LogActionImpl(node, Charset.defaultCharset());
+            la = new LogActionImpl(node);
             node.addAction(la);
         }
         OutputStream os = new FileOutputStream(la.getLogFile(), true);
         if (filter != null) {
             os = filter.decorateLogger((AbstractBuild) null, os);
         }
-        final StreamTaskListener result = new StreamTaskListener(os);
+        final StreamTaskListener result = new StreamTaskListener(os, la.getCharset());
         final AtomicReference<GraphListener> graphListener = new AtomicReference<>();
         LOGGER.log(Level.FINE, "opened log for {0}", node.getDisplayFunctionName());
         graphListener.set(new GraphListener.Synchronous() {
@@ -101,12 +101,11 @@ public class LogActionImpl extends LogAction implements FlowNodeAction, Persiste
     private transient volatile File log;
     private String charset;
 
-    private LogActionImpl(FlowNode parent, Charset charset) throws IOException {
+    private LogActionImpl(FlowNode parent) throws IOException {
         if (!parent.isActive()) {
             throw new IOException("cannot start writing logs to a finished node " + parent + " " + parent.getDisplayFunctionName() + " in " + parent.getExecution());
         }
         this.parent = parent;
-        this.charset = charset.name();
     }
 
     @Restricted(DoNotUse.class) // Jelly
@@ -162,8 +161,11 @@ public class LogActionImpl extends LogAction implements FlowNodeAction, Persiste
     }
 
     private Charset getCharset() {
-        if(charset==null)   return Charset.defaultCharset();    // just being defensive
-        return Charset.forName(charset);
+        if (charset == null) { // new style
+            return StandardCharsets.UTF_8;
+        } else { // historical
+            return Charset.forName(charset);
+        }
     }
 
     @Override public String toString() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -163,7 +163,10 @@ public class RunWrapperTest {
                         "echo \"currentBuild.projectName='${currentBuild.projectName}'\"\n" +
                         "echo \"currentBuild.fullProjectName='${currentBuild.fullProjectName}'\"\n", true));
                 WorkflowRun b = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-                r.j.assertLogContains("currentBuild.fullDisplayName='this-folder » this-job #1'", b);
+                { // TODO mojibake until https://github.com/jenkinsci/workflow-job-plugin/pull/89 is released and can be consumed as a test dependency; expect this-folder » this-job #1
+                    r.j.assertLogContains("currentBuild.fullDisplayName='this-folder", b);
+                    r.j.assertLogContains("this-job #1'", b);
+                }
                 r.j.assertLogContains("currentBuild.projectName='this-job'", b);
                 r.j.assertLogContains("currentBuild.fullProjectName='this-folder/this-job'", b);
             }


### PR DESCRIPTION
[JEP-206](https://github.com/jenkinsci/jep/blob/master/jep/206/README.adoc)

Not exactly pulled out of #15, but in the same vein and complementary. One component of the solution only; as noted in https://github.com/jenkinsci/workflow-job-plugin/pull/89, users will need to update multiple plugins to resolve issues.