### PR TITLE
[JENKINS-52001] - Update JBoss Marshalling to 2.0.5.Final in order to get Java 9+ fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,8 @@
     <properties>
         <revision>2.19</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.62</jenkins.version>
+        <jenkins-core.version>2.129-20180618.135411-1</jenkins-core.version>
+        <jenkins-war.version>2.129-20180618.135443-1</jenkins-war.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <git-plugin.version>3.7.0</git-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
-            <version>1.4.12.jenkins-3</version> <!-- https://github.com/jglick/jboss-marshalling/compare/1.4.12.Final...1.4.12.jenkins-3 -->
+            <version>2.0.5.Final</version> <!-- https://github.com/jglick/jboss-marshalling/compare/1.4.12.Final...1.4.12.jenkins-3 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
This patch updates JBoss Marshalling to 2.0.5.Final and removes custom fork originally created by @jglick . https://github.com/jglick/jboss-marshalling/tree/jenkins . AFAICT the only difference between branches is that @jglick removed Multi-Release JARs, but actually we need it here in order to get Pipeline running on Java 10.

I was able to build it and get several demo Pipelines running. Build command:

```
 mvn clean package -DskipTests --errors -Denforcer.skip -Danimal.sniffer.skip
```

Bug for Enforcer Extras: https://issues.jenkins-ci.org/browse/JENKINS-52006
Bug for Animal Sniffer: https://issues.jenkins-ci.org/browse/JENKINS-52007 

Working on them

We may also need https://issues.jboss.org/browse/JBMAR-218

@jenkinsci/java10-support @svanoort @jglick @reviewbybees 