### PR TITLE
[JENKINS-52007] - Plugin POM 3.28: Update Animal Sniffer and other Maven plugins towards Java 11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.12</version>
+        <version>3.16-20180621.084622-1</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -72,8 +72,8 @@
         <workflow-scm-step-plugin.version>2.6</workflow-scm-step-plugin.version>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
+        <animal.sniffer.version>1.17-SNAPSHOT</animal.sniffer.version>
         <enforcer.skip>true</enforcer.skip> <!-- Ignore the higher classfile version for JBoss Marshallig until we resolve JENKINS-52014 and JENKINS-52006 -->
-        <animal.sniffer.skip>true</animal.sniffer.skip> <!-- Temporary for JENKINS-52007 -->
         <maven.test.skip>true</maven.test.skip>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.16-20180621.084622-1</version>
+        <version>3.16</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -72,7 +72,7 @@
         <workflow-scm-step-plugin.version>2.6</workflow-scm-step-plugin.version>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-        <animal.sniffer.version>1.17-SNAPSHOT</animal.sniffer.version>
+        <animal.sniffer.version>1.17</animal.sniffer.version>
         <enforcer.skip>true</enforcer.skip> <!-- Ignore the higher classfile version for JBoss Marshallig until we resolve JENKINS-52014 and JENKINS-52006 -->
         <maven.test.skip>true</maven.test.skip>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.16</version>
+        <version>3.28</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -72,7 +72,6 @@
         <workflow-scm-step-plugin.version>2.6</workflow-scm-step-plugin.version>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
-        <animal.sniffer.version>1.17</animal.sniffer.version>
         <enforcer.skip>true</enforcer.skip> <!-- Ignore the higher classfile version for JBoss Marshallig until we resolve JENKINS-52014 and JENKINS-52006 -->
         <maven.test.skip>true</maven.test.skip>
     </properties>


### PR DESCRIPTION
Downstream of:

* https://github.com/jenkinsci/plugin-pom/pull/114
* https://github.com/mojohaus/animal-sniffer/pull/50

We need a release of Animal Sniffer to integrate it, but no hurry

CC @ndeloof @olamy @svanoort 

