### PR TITLE
Add comment to update help.html

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -49,6 +49,8 @@ import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
 
 /**
  * Allows {@link Whitelisted} access to selected attributes of a {@link Run} without requiring Jenkins API imports.
+ *
+ * NOTE: if modifying this class, please remember to manually update Runwrapper/help.html
  */
 public final class RunWrapper implements Serializable {
 


### PR DESCRIPTION
This help file is used to document `currentBuild`, for example at 
https://opensource.triology.de/jenkins/pipeline-syntax/globals#currentBuild