### PR TITLE
[WIP] Initial implementation for simple option for exposing build causes in a safe way

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,15 @@
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>annotation-indexer</artifactId>
+                <version>1.12</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -87,22 +87,24 @@ public final class RunWrapper implements Serializable {
 
     @Whitelisted
     public List<Cause> getBuildCauses() {
-        if (getRawBuild() != null) {
-            return Collections.unmodifiableList(getRawBuild().getCauses());
+        Run<?,?> run = getRawBuild();
+        if (run != null) {
+            return Collections.unmodifiableList(run.getCauses());
         }
         else {
-            return new ArrayList<Cause>();
+            return Collections.emptyList();
         }
     }
 
     @Whitelisted
     public List<Cause> getBuildCauses(Class<Cause> causeType) {
-        if (getRawBuild() != null) {
+        Run<?,?> run = getRawBuild();
+        if (run != null) {
             return Collections.unmodifiableList(
-                    getRawBuild().getCauses().stream().filter(cause -> causeType.isInstance(cause)).collect(Collectors.toList()));
+                    run.getCauses().stream().filter(cause -> causeType.isInstance(cause)).collect(Collectors.toList()));
         }
         else {
-            return new ArrayList<Cause>();
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -86,14 +87,13 @@ public final class RunWrapper implements Serializable {
 
     @Whitelisted
     public List<Cause> getBuildCauses() {
-        return Collections.unmodifiableList(getRawBuild().getCauses());
+        return Collections.unmodifiableList(Objects.requireNonNull(getRawBuild()).getCauses());
     }
 
     @Whitelisted
     public List<Cause> getBuildCauses(Class<Cause> causeType) {
-        return Collections.unmodifiableList(getRawBuild().getCauses().stream().filter(cause -> causeType.isInstance(cause)
-        ).collect
-                (Collectors.toList()));
+        return Collections.unmodifiableList(Objects.requireNonNull(getRawBuild().getCauses()).stream().filter(cause -> causeType
+                .isInstance(cause)).collect(Collectors.toList()));
     }
 
     @Whitelisted

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -33,6 +33,7 @@ import hudson.model.TaskListener;
 import hudson.scm.ChangeLogSet;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -40,10 +41,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jenkins.scm.RunWithSCM;
+
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
 
@@ -79,6 +82,18 @@ public final class RunWrapper implements Serializable {
             throw new AbortException("No build record " + externalizableId + " could be located.");
         }
         return r;
+    }
+
+    @Whitelisted
+    public List<Cause> getBuildCauses() {
+        return Collections.unmodifiableList(getRawBuild().getCauses());
+    }
+
+    @Whitelisted
+    public List<Cause> getBuildCauses(Class<Cause> causeType) {
+        return Collections.unmodifiableList(getRawBuild().getCauses().stream().filter(cause -> causeType.isInstance(cause)
+        ).collect
+                (Collectors.toList()));
     }
 
     @Whitelisted

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -105,7 +105,6 @@ public final class RunWrapper implements Serializable {
             return new ArrayList<Cause>();
         }
     }
-    }
 
     @Whitelisted
     public void setResult(String result) throws AbortException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -87,13 +87,24 @@ public final class RunWrapper implements Serializable {
 
     @Whitelisted
     public List<Cause> getBuildCauses() {
-        return Collections.unmodifiableList(Objects.requireNonNull(getRawBuild()).getCauses());
+        if (getRawBuild() != null) {
+            return Collections.unmodifiableList(getRawBuild().getCauses());
+        }
+        else {
+            return new ArrayList<Cause>();
+        }
     }
 
     @Whitelisted
     public List<Cause> getBuildCauses(Class<Cause> causeType) {
-        return Collections.unmodifiableList(Objects.requireNonNull(getRawBuild().getCauses()).stream().filter(cause -> causeType
-                .isInstance(cause)).collect(Collectors.toList()));
+        if (getRawBuild() != null) {
+            return Collections.unmodifiableList(
+                    getRawBuild().getCauses().stream().filter(cause -> causeType.isInstance(cause)).collect(Collectors.toList()));
+        }
+        else {
+            return new ArrayList<Cause>();
+        }
+    }
     }
 
     @Whitelisted


### PR DESCRIPTION
**WIP** **DO NOT MERGE**

One proposed approach to exposing build causes in a safe way for pipeline developers.  This approach depends on whitelisting the desired methods of any `Cause` implementations that you want to expose to pipeline developers ([see related PR for the script-security plugin which whitelists current implementations by default](https://github.com/jenkinsci/script-security-plugin/pull/225)).  

This approach has the advantage of allowing a user to find all `Cause`s that are a subclass of another `Cause`, as well as being very simple in its implementation.

Compare this approach against [this PR, which exposes @Exported fields as a `Map` of `Map`s using org.kohsuke.stapler.export.ModelBuilder](url)

**NOTE** linked PR's not yet created, will update shortly 

**Example pipeline Usage**
`pipeline {
    agent any

    stages {
        stage('debug') {
            steps {
                echo currentBuild.getBuildCauses().toString();
                script {
                    echo "---- test getting all causes --"
                    def causes = currentBuild.getBuildCauses()
                    echo "causes-->" + causes
                    echo "causes.size() -->" +causes.size()
                    for (cause in causes) {
                        echo "cause: " + cause.class
                        echo "short desc ->" + cause.getShortDescription()
                    }
                    
                    echo "---------- get specific cause types ----------"

                    causes = currentBuild.getBuildCauses(hudson.model.Cause$UserIdCause.class)
                    echo "causes-->" + causes
                    echo "causes.size() -->" +causes.size()
                    for (cause in causes) {
                        echo "cause: " + cause.class
                        echo "short desc ->" + cause.getShortDescription()
                    }

                    echo "------- get causes by superclass ------"
                    causes = currentBuild.getBuildCauses(hudson.model.Cause.class)
                    echo "causes-->" + causes
                    echo "causes.size() -->" +causes.size()
                    for (cause in causes) {
                        echo "cause: " + cause.class
                        echo "short desc ->" + cause.getShortDescription()
                    }
                }
            }
        }
        stage('declarative example') {
            when {
                expression {
                    currentBuild.getBuildCauses().get(0).getShortDescription() == 'Started by user anonymous'
                }
            }
            steps {
                echo 'we found our cause!'
            }
        }
    }
}

`
