### PR TITLE
[JENKINS-54227] Safely expose the Cause(s) associated with the current build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.22</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.130</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.22</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.130</jenkins.version>
+        <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -150,17 +150,28 @@ public final class RunWrapper implements Serializable {
         }
     }
 
+    /**
+     * Filters the returned list by the type of <code>Cause</code> class passed as input
+     * ex. <code>getBuildCauess('hudson.model.Cause$UserIdCause')</code> would return only
+     * <code>Cause</code>s of that type
+     *
+     * @param className A string containing the fully qualified name for the class type to filter the result list by
+     * @return a <code>JSONArray</code> of <code>Cause</code>s of the specified type
+     * @throws IOException
+     */
     @Whitelisted
-    public JSONArray getBuildCauses(Class<Cause> clazz) throws IOException {
+    public JSONArray getBuildCauses(String className) throws IOException, ClassNotFoundException {
+        Class clazz = Class.forName(className);
         JSONArray result = new JSONArray();
-        StringWriter w = new StringWriter();
 
         for(Cause cause : build().getCauses()) {
             if (clazz.isInstance(cause)) {
+                StringWriter w = new StringWriter();
                 CauseAction causeAction = new CauseAction(cause);
                 DataWriter writer = JSON.createDataWriter(causeAction, w);
                 Model<CauseAction> model = new ModelBuilder().get(CauseAction.class);
                 model.writeTo(causeAction, writer);
+                // return a slightlly cleaner object by removing the outer object
                 result.add(JSONObject.fromObject(w.toString()).getJSONArray("causes").get(0));
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -134,20 +134,8 @@ public final class RunWrapper implements Serializable {
     }
 
     @Whitelisted
-    public JSONArray getBuildCauses() throws IOException {
-        CauseAction causeAction = build().getAction(CauseAction.class);
-
-        if (causeAction != null) {
-            StringWriter w = new StringWriter();
-            DataWriter writer = JSON.createDataWriter(causeAction, w);
-            Model<CauseAction> model = new ModelBuilder().get(CauseAction.class);
-            model.writeTo(causeAction, writer);
-                JSONObject result =  JSONObject.fromObject(w.toString());
-                // return a slightlly cleaner object
-                return result.getJSONArray("causes");
-        } else {
-            return new JSONArray();
-        }
+    public JSONArray getBuildCauses() throws IOException, ClassNotFoundException {
+        return getBuildCauses("hudson.model.Cause");
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.support.steps.build;
 import hudson.AbortException;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
+import hudson.model.CauseAction;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -35,6 +36,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import java.io.IOException;
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,8 +46,14 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jenkins.scm.RunWithSCM;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.support.actions.EnvironmentAction;
+import org.kohsuke.stapler.export.DataWriter;
+import org.kohsuke.stapler.export.Model;
+import org.kohsuke.stapler.export.ModelBuilder;
+import static org.kohsuke.stapler.export.Flavor.JSON;
 
 /**
  * Allows {@link Whitelisted} access to selected attributes of a {@link Run} without requiring Jenkins API imports.
@@ -123,6 +131,40 @@ public final class RunWrapper implements Serializable {
     @Whitelisted
     public int getNumber() throws AbortException {
         return build().getNumber();
+    }
+
+    @Whitelisted
+    public JSONArray getBuildCauses() throws IOException {
+        CauseAction causeAction = build().getAction(CauseAction.class);
+
+        if (causeAction != null) {
+            StringWriter w = new StringWriter();
+            DataWriter writer = JSON.createDataWriter(causeAction, w);
+            Model<CauseAction> model = new ModelBuilder().get(CauseAction.class);
+            model.writeTo(causeAction, writer);
+                JSONObject result =  JSONObject.fromObject(w.toString());
+                // return a slightlly cleaner object
+                return result.getJSONArray("causes");
+        } else {
+            return new JSONArray();
+        }
+    }
+
+    @Whitelisted
+    public JSONArray getBuildCauses(Class<Cause> clazz) throws IOException {
+        JSONArray result = new JSONArray();
+        StringWriter w = new StringWriter();
+
+        for(Cause cause : build().getCauses()) {
+            if (clazz.isInstance(cause)) {
+                CauseAction causeAction = new CauseAction(cause);
+                DataWriter writer = JSON.createDataWriter(causeAction, w);
+                Model<CauseAction> model = new ModelBuilder().get(CauseAction.class);
+                model.writeTo(causeAction, writer);
+                result.add(JSONObject.fromObject(w.toString()).getJSONArray("causes").get(0));
+            }
+        }
+        return result;
     }
 
     @Whitelisted

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -1,4 +1,6 @@
 <dl>
+    <dt><code>getBuildCauses</code></dt><dd>Returns a JSON array of build causes for the current build</dd>
+    <dt><code>getBuildCauses(Class&lt;Cause&gt;)</code></dt><dd>Returns a <code>JSON array</code> of build causes of type <code>Cause</code> for the current build, or an empty <code>JSON array</code> if no causes of the specified type apply to the current build</code></dd>
     <dt><code>number</code></dt><dd>build number (integer)</dd>
     <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>
     <dt><code>currentResult</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code>. Will never be null.</dd>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -1,6 +1,6 @@
 <dl>
     <dt><code>getBuildCauses</code></dt><dd>Returns a JSON array of build causes for the current build</dd>
-    <dt><code>getBuildCauses(Class&lt;Cause&gt;)</code></dt><dd>Returns a <code>JSON array</code> of build causes of type <code>Cause</code> for the current build, or an empty <code>JSON array</code> if no causes of the specified type apply to the current build</code></dd>
+    <dt><b>EXPERIMENTAL - MAY CHANGE</b>  <code>getBuildCauses(String causeClass)</code></dt><dd>Takes a string representing the fully qualified <code>Cause</code> class and returns a <code>JSON array</code> of build causes filtered by that type for the current build, or an empty <code>JSON array</code> if no causes of the specified type apply to the current build</code></dd>
     <dt><code>number</code></dt><dd>build number (integer)</dd>
     <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>
     <dt><code>currentResult</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code>. Will never be null.</dd>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -263,12 +263,12 @@ public class RunWrapperTest {
                                   + "\"userId\":\"tester\",\"userName\":\"anonymous\"}]", run);
 
             // test filtering build causes
-            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses(hudson.model.Cause$UserIdCause)"
+            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')"
                                                     + ".toString()\n"
-                                                    + "assert currentBuild.getBuildCauses(hudson.model"
-                                                    + ".Cause$UserIdCause).size() == 1\n"
-                                                    + "assert currentBuild.getBuildCauses(hudson.model"
-                                                    + ".Cause$UserIdCause)[0].userId == 'tester2'\n",
+                                                    + "assert currentBuild.getBuildCauses('hudson.model"
+                                                    + ".Cause$UserIdCause').size() == 1\n"
+                                                    + "assert currentBuild.getBuildCauses('hudson.model"
+                                                    + ".Cause$UserIdCause')[0].userId == 'tester2'\n",
                                                     true));
 
             run = r.j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -232,6 +232,7 @@ public class RunWrapperTest {
     }
 
     @Test
+    @Issue("JENKINS-54227")
     public void buildCauseTest() {
         r.addStep(new Statement() {
             @Override

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.workflow.support.steps.build;
 
+import hudson.model.Cause;
+import hudson.model.CauseAction;
 import hudson.model.FreeStyleProject;
 import hudson.model.Messages;
 import hudson.model.ParametersDefinitionProperty;
@@ -227,6 +229,56 @@ public class RunWrapperTest {
                 r.j.assertLogContains("b.buildVariables.param='something'", b);
             }
         });
+    }
+
+    @Test
+    public void buildCauseTest() {
+        r.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+            WorkflowJob job = r.j.createProject(WorkflowJob.class, "test");
+            // test with a single build cause
+            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses().toString()\n"
+                                                    + "assert currentBuild.getBuildCauses().size() == 1\n"
+                                                    + "assert currentBuild.getBuildCauses()[0].userId == 'tester'\n",
+                                                    true));
+            WorkflowRun run = r.j.assertBuildStatusSuccess(job.scheduleBuild2(0, new CauseAction(new Cause
+                    .UserIdCause("tester"))));
+            r.j.assertLogContains("[{\"_class\":\"hudson.model.Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\",\"userId\":\"tester\",\"userName\":\"anonymous\"}]",run);
+
+            // test with mutiple build causes
+            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses().toString()\n"
+                                                    + "assert currentBuild.getBuildCauses().size() == 2\n"
+                                                    + "assert currentBuild.getBuildCauses()[0].note == 'this is a note'\n"
+                                                    + "assert currentBuild.getBuildCauses()[1].userId == 'tester'\n",
+                                                    true));
+
+            run = r.j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
+                .RemoteCause("upstream.host","this is a note"), new Cause.UserIdCause("tester"))));
+            r.j.assertLogContains("[{\"_class\":\"hudson.model.Cause$RemoteCause\",\"shortDescription\":\"Started by "
+                                  + "remote host upstream.host with note: this is a note\",\"addr\":\"upstream"
+                                  + ".host\",\"note\":\"this is a note\"},{\"_class\":\"hudson.model"
+                                  + ".Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\","
+                                  + "\"userId\":\"tester\",\"userName\":\"anonymous\"}]", run);
+
+            // test filtering build causes
+            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses(hudson.model.Cause$UserIdCause)"
+                                                    + ".toString()\n"
+                                                    + "assert currentBuild.getBuildCauses(hudson.model"
+                                                    + ".Cause$UserIdCause).size() == 1\n"
+                                                    + "assert currentBuild.getBuildCauses(hudson.model"
+                                                    + ".Cause$UserIdCause)[0].userId == 'tester2'\n",
+                                                    true));
+
+            run = r.j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
+                    .RemoteCause("upstream.host","this is a note"), new Cause.UserIdCause("tester2"))));
+            r.j.assertLogContains("[{\"_class\":\"hudson.model"
+                                  + ".Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\","
+                                  + "\"userId\":\"tester2\",\"userName\":\"anonymous\"}]", run);
+
+            }
+        });
+
     }
 
     @Issue("JENKINS-31576")


### PR DESCRIPTION
Use stapler's `ModelBuilder` to create a JSON representation of a `Cause`s `@Exported` fields:

For example, a build with a `hudson.model.Cause$UserId` cause produce the following output:
 
```
[{ "_class":"hudson.model.Cause$UserIdCause", "shortDescription":"Started by user anonymous", "userId":"tester", "userName":"anonymous" }]
```

The JSON objects in the resulting array can be used directly in a pipeline:

```
assert currentBuild.getBuildCauses().size() == 1
assert currentBuild.getBuildCauses()[0].userId == 'tester'
echo currentBuild.getBuildCauses()[0].shortDescription
```

Additionally, you can filter the result of `currentBuild.getBuildCauses()` by passing a class (or superclass) of the type you would like to filter by.  For example, to get a list of build `Cause`s that only contains `Cause`s of type `hudson.model.Cause$UserIdCause`, call the method like this:

`
echo currentBuild.getBuildCauses(hudson.model.Cause$UserIdCause).size()
`
Calling the method with `hudson.model.Cause` as a parameter will return all the `Cause`s associated with a build, since all `Cause`s are a sub-class of this type.