### PR TITLE
[JENKINS-55174] Update JBoss marshalling and unignore fixed tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,13 +99,7 @@
             <!-- Required for running with Java 9+ -->
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
-            <version>2.0.5.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>annotation-indexer</artifactId>
-            <version>1.12</version>
-            <scope>test</scope>
+            <version>2.0.6.Final</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ThrowablePickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ThrowablePickleTest.java
@@ -47,7 +47,6 @@ public class ThrowablePickleTest {
     @Rule public LoggerRule logging = new LoggerRule().record(ThrowablePickle.class, Level.FINE);
 
     @Issue("JENKINS-51390")
-    @Ignore("Still has problems with new JBoss Marshalling, temporarily disabled while debugging.")
     @Test public void smokes() throws Exception {
         String beName = BadException.class.getName();
         rr.then(r -> {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/SerializationSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/SerializationSecurityTest.java
@@ -108,7 +108,6 @@ public class SerializationSecurityTest {
 
     /** @see SerializableClass#callReadObject */
     @For(RiverReader.class)
-    @Ignore("Still has problems with new JBoss Marshalling, temporarily disabled while debugging.")
     @Test public void readObjectChecksSandbox() {
         rr.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -132,7 +131,6 @@ public class SerializationSecurityTest {
 
     /** @see SerializableClass#callReadResolve */
     @For(RiverReader.class)
-    @Ignore("Still has problems with new JBoss Marshalling, temporarily disabled while debugging.")
     @Test public void readResolveChecksSandbox() {
         rr.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -155,7 +153,6 @@ public class SerializationSecurityTest {
 
     /** @see RiverUnmarshaller#doReadNewObject */
     @For(RiverReader.class)
-    @Ignore("Still has problems with new JBoss Marshalling, temporarily disabled while debugging.")
     @Test public void readExternalChecksSandbox() {
         rr.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -179,7 +176,6 @@ public class SerializationSecurityTest {
 
     /** @see SerializableClass#callNoArgConstructor */
     @For(RiverReader.class)
-    @Ignore("Still has problems with new JBoss Marshalling, temporarily disabled while debugging.")
     @Test public void externalizableNoArgConstructorChecksSandbox() {
         rr.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
@@ -208,7 +204,6 @@ public class SerializationSecurityTest {
      * @see SerializableClass#callObjectInputConstructor
      */
     @For(RiverReader.class)
-    @Ignore("Still has problems with new JBoss Marshalling, temporarily disabled while debugging.")
     @Test public void externalizableObjectInputConstructorChecksSandbox() {
         rr.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -60,7 +60,6 @@ public class RunWrapperTest {
     @Rule public GitSampleRepoRule sampleRepo1 = new GitSampleRepoRule();
     @Rule public GitSampleRepoRule sampleRepo2 = new GitSampleRepoRule();
 
-    @Ignore("Still has problems with new JBoss Marshalling, temporarily disabled while debugging.")
     @Test public void historyAndPickling() {
         r.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {


### PR DESCRIPTION
See [JENKINS-55174](https://issues.jenkins-ci.org/browse/JENKINS-55174). Based against #84.

It looks like the root cause of the NPE we were seeing was [JBMAR-221](https://issues.jboss.org/browse/JBMAR-221), which was fixed in JBoss Marshalling 2.0.6.Final, so I've updated to that version and unignored the previously-failing tests.

CC @jenkinsci/java11-support 