### PR TITLE
Update POM for next release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.29</version>
+        <version>3.32</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -62,11 +62,10 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <revision>3.0-java11-alpha-2</revision>
+        <revision>3.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
-        <plugin.minimumJavaVersion>11</plugin.minimumJavaVersion>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <git-plugin.version>3.7.0</git-plugin.version>
@@ -227,25 +226,6 @@
                 <configuration>
                     <compatibleSinceVersion>3.0</compatibleSinceVersion>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>display-info</id>
-                        <configuration>
-                            <rules>
-                                <enforceBytecodeVersion>
-                                    <excludes combine.children="append">
-                                        <!-- Prevents enforcer complaining about multi-release JAR -->
-                                        <exclude>org.jboss.marshalling:jboss-marshalling-river</exclude>
-                                        <exclude>org.jboss.marshalling:jboss-marshalling</exclude>
-                                    </excludes>
-                                </enforceBytecodeVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ThrowablePickleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/ThrowablePickleTest.java
@@ -32,7 +32,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -42,7 +42,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.runners.model.Statement;


### PR DESCRIPTION
Minor updates just to get things ready for the release (which will support Java 8 in addition to newer Java versions). Once this PR is merged, we should merge the `java11` branch into `master` and release it.