### PR TITLE
Remove dependency on obsolete workflow-scm-step tests artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <git-plugin.version>3.7.0</git-plugin.version>
-        <workflow-scm-step-plugin.version>2.6</workflow-scm-step-plugin.version>
+        <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>
         <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
     </properties>
@@ -190,13 +190,6 @@
                     <artifactId>annotation-indexer</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <version>${workflow-scm-step-plugin.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Fixes PCT failures when running against workflow-scm-step 2.7. As of jenkinsci/workflow-scm-step-plugin#17, the workflow-scm-steps tests artifact is no longer produced, because the useful classes it had were moved to scm-api in jenkinsci/workflow-scm-step-plugin#15 (landed originally in workflow-scm-step-2.5, i.e. the tests artifact has been obsolete for a long time).

CC @halkeye 