### PR TITLE
Add class filter entry for TraceInformation$IncompleteObjectInfo

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,2 +1,3 @@
 org.jboss.marshalling.TraceInformation$FieldInfo
+org.jboss.marshalling.TraceInformation$IncompleteObjectInfo
 org.jboss.marshalling.TraceInformation$ObjectInfo


### PR DESCRIPTION
A warning for this class came up recently in Evergreen error logs. I recall some discussion around this type (and one other, perhaps `TraceInformation$IndexInfo`?) in the past, but can not find any record of such a discussion.  The [IncompleteObjectInfo class](https://github.com/jboss-remoting/jboss-marshalling/blob/72e4eb2a77f023dec769dcdeea2307dc79661c11/api/src/main/java/org/jboss/marshalling/TraceInformation.java#L299-L319) looks harmless from a serialization/deserialization security perspective.

Maybe the reason we are seeing this now is that in some cases an error thrown as a result of the 2.x to 3.x upgrade uses this type in an error message, but other than that I think it could be used if the serialized file is corrupted or the implementations of serialization-related methods are incorrect (as in [this reproduction](https://gist.github.com/dwnusbaum/480a0e51c013370bfe6e987d3f43b716)). It doesn't seem valuable to me to try to reproduce the warning in a test here, but I would be happy to do so if reviewers think it would be useful.

I don't know if the warning really had any impact to end users, since as far as I can tell in my reproduction the only difference is that without the class filter entry, the exception is wrapped in `hudson.remoting.ProxyException`, but with the entry the underlying exception type is exposed.

Builds on #50.