### PR TITLE
Java 11 readiness: build using recommended configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.33</version>
+        <version>3.42</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl.java
@@ -157,7 +157,7 @@ public class LogActionImpl extends LogAction implements FlowNodeAction, Persiste
     }
 
     /**
-     * Used from <tt>console.jelly</tt> to write annotated log to the given output.
+     * Used from <code>console.jelly</code> to write annotated log to the given output.
      */
     @Restricted(DoNotUse.class) // Jelly
     public void writeLogTo(long offset, XMLOutput out) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction.java
@@ -63,7 +63,7 @@ public class LogStorageAction extends LogAction implements FlowNodeAction, Persi
     }
 
     /**
-     * Used from <tt>console.jelly</tt> to write annotated log to the given output.
+     * Used from <code>console.jelly</code> to write annotated log to the given output.
      */
     @Restricted(DoNotUse.class) // Jelly
     public void writeLogTo(long offset, XMLOutput out) throws IOException {


### PR DESCRIPTION
Using the right variations of Jenkins versions, JDK 8 & 11, Windows/Linux...

For Java 11 readiness, apply recommended configuration:
https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime

And fixing what was revealed through this.

@jenkinsci/java11-support 
