### PR TITLE
setKeepLog from builds other than current

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -120,12 +120,9 @@ public final class RunWrapper implements Serializable {
             build().setDisplayName(n);
         }
     }
-	
+
     @Whitelisted
     public void setKeepLog(boolean b) throws IOException {
-        if (!currentBuild) {
-            throw new SecurityException("can only set the keepLog property on the current build");
-        }
         try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
             build().keepLog(b);
         }


### PR DESCRIPTION
We have a use case where we automatically mark some of the builds (releases) as "Keep forever". When a new build is marked, we would also like to be able to unmark the previous "Keep forever" builds, but the following check prevents us from doing so:

```java
public void setKeepLog(boolean b) throws IOException {
    if (!currentBuild) {
        throw new SecurityException("can only set the keepLog property on the current build");
    }

    //[...]
}
```

It would be nice if we could lift this restriction, or add a new method that allows this (and maybe requires the explicit approval from the Jenkins admin).