### PR TITLE
Use waitForMessage in tests to reduce flakes

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/SerializationSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/SerializationSecurityTest.java
@@ -256,8 +256,8 @@ public class SerializationSecurityTest {
     private static void safe(JenkinsRule r, WorkflowRun b) throws Exception {
         assertNull(r.jenkins.getSystemMessage());
         assertEquals(Result.FAILURE, b.getResult());
+        r.waitForMessage("staticMethod jenkins.model.Jenkins getInstance", b);
         r.assertLogNotContains("should not still have", b);
-        r.assertLogContains("staticMethod jenkins.model.Jenkins getInstance", b);
     }
 
 }


### PR DESCRIPTION
Hi we're experiencing flakey tests trying to integrate the next bom line,

example:
```
Expected: a string containing "broken condition"
     but: was "Started
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] Start of Pipeline
[Pipeline] waitUntil
[Pipeline] {
[Pipeline] semaphore
[Pipeline] }
Will try again after 0.25 sec
[Pipeline] {
[Pipeline] semaphore
[Pipeline] }
[Pipeline] // waitUntil
[Pipeline] End of Pipeline
```

@jglick suggested replacing assertLogContains with waitForMessage
https://github.com/jenkinsci/bom/pull/110#issuecomment-594782396