### PR TITLE
Add currentResultOrdinal to RunWrapper

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -192,6 +192,12 @@ public final class RunWrapper implements Serializable {
     }
 
     @Whitelisted
+    public @Nonnull int getCurrentResultOrdinal() throws AbortException {
+        Result result = build().getResult();
+        return result != null ? result.ordinal : Result.SUCCESS.ordinal;
+    }
+
+    @Whitelisted
     public boolean resultIsBetterOrEqualTo(String other) throws AbortException {
         Result result = build().getResult();
         if (result == null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -213,6 +213,23 @@ public class RunWrapperTest {
         });
     }
 
+    @Test public void getCurrentResultOrdinal() {
+        r.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                MockFolder folder = r.j.createFolder("this-folder");
+                WorkflowJob p = folder.createProject(WorkflowJob.class, "current-result-job");
+                p.setDefinition(new CpsFlowDefinition(
+                        "echo \"initial currentBuild.currentResult='${currentBuild.currentResultOrdinal}'\"\n" +
+                        "currentBuild.result = 'UNSTABLE'\n" +
+                        "echo \"final currentBuild.currentResult='${currentBuild.currentResultOrdinal}'\"\n" +
+                        true));
+                WorkflowRun b = r.j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+                r.j.assertLogContains("initial currentBuild.currentResult='" + Result.SUCCESS.ordinal + "'", b);
+                r.j.assertLogContains("final currentBuild.currentResult='" + Result.UNSTABLE.ordinal + "'", b);
+            }
+        });
+    }
+
     @Issue("JENKINS-36528")
     @Test public void freestyleEnvVars() {
         r.addStep(new Statement() {


### PR DESCRIPTION
Sometimes it's useful to access the ordinal value of currentResult. For example, we want to send this value to Graphite as a metric.

This PR adds "getCurrentResultOrdinal" as a method of RunWrapper, and its test.