### PR TITLE
[JENKINS-47101] Add a default EnvironmentExpander that registers password parameters as sensitive variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.176.x</artifactId>
-                <version>9</version>
+                <version>16</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -31,11 +31,18 @@ import hudson.console.ConsoleLogFilter;
 import hudson.model.Computer;
 import hudson.model.Job;
 import hudson.model.Node;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.PasswordParameterValue;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -77,6 +84,9 @@ public abstract class DefaultStepContext extends StepContext {
             return value;
         } else if (key == TaskListener.class) {
             return key.cast(getListener(false));
+        } else if (key == EnvironmentExpander.class) {
+            // Only called when `value == null` so that it does not override expanders contributed by steps.
+            return key.cast(new PasswordParameterEnvironmentExpander(get(Run.class)));
         } else if (Node.class.isAssignableFrom(key)) {
             Computer c = get(Computer.class);
             Node n = null;
@@ -171,5 +181,36 @@ public abstract class DefaultStepContext extends StepContext {
      * Automatically available from {@link #get}.
      */
     protected abstract @Nonnull FlowNode getNode() throws IOException;
+
+    /**
+     * Default implementation of {@link EnvironmentExpander} that recognizes password parameters as sensitive variables.
+     */
+    private static class PasswordParameterEnvironmentExpander extends EnvironmentExpander {
+        private static final long serialVersionUID = 1L;
+
+        private final Set<String> passwordParameterVariables;
+
+        public PasswordParameterEnvironmentExpander(Run<?, ?> run) {
+            ParametersAction action = run.getAction(ParametersAction.class);
+            if (action != null) {
+                passwordParameterVariables = action.getParameters().stream()
+                        .filter(PasswordParameterValue.class::isInstance)
+                        .map(ParameterValue::getName)
+                        .collect(Collectors.toCollection(() -> new HashSet<>())); // Make sure the set is serializable.
+            } else {
+                passwordParameterVariables = Collections.emptySet();
+            }
+        }
+
+        @Override
+        public void expand(EnvVars ev) {
+            // Do nothing.
+        }
+
+        @Override
+        public Set<String> getSensitiveVariables() {
+            return passwordParameterVariables;
+        }
+    }
 
 }


### PR DESCRIPTION
See [JENKINS-47101](https://issues.jenkins-ci.org/browse/JENKINS-47101).

Before the fix for JENKINS-47101 in https://github.com/jenkinsci/workflow-cps-plugin/pull/370, password parameters would have been masked in step arguments, so I think we need to make sure that they continue to be masked, which requires us to integrate with the new API from https://github.com/jenkinsci/workflow-step-api-plugin/pull/57.

We need to add a test for this case over in `workflow-cps`.