### PR TITLE
[JENKINS-64282] Do not add empty passwords to sensitive variables list

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -195,7 +195,7 @@ public abstract class DefaultStepContext extends StepContext {
             ParametersAction action = run.getAction(ParametersAction.class);
             if (action != null) {
                 passwordParameterVariables = action.getParameters().stream()
-                        .filter(e -> PasswordParameterValue.class.isInstance(e)
+                        .filter(e -> e instanceof PasswordParameterValue
                                         && !((Secret) e.getValue()).getPlainText().isEmpty())
                         .map(ParameterValue::getName)
                         .collect(Collectors.toCollection(() -> new HashSet<>())); // Make sure the set is serializable.

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/DefaultStepContext.java
@@ -45,6 +45,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import hudson.util.Secret;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
@@ -194,7 +195,8 @@ public abstract class DefaultStepContext extends StepContext {
             ParametersAction action = run.getAction(ParametersAction.class);
             if (action != null) {
                 passwordParameterVariables = action.getParameters().stream()
-                        .filter(PasswordParameterValue.class::isInstance)
+                        .filter(e -> PasswordParameterValue.class.isInstance(e)
+                                        && !((Secret) e.getValue()).getPlainText().isEmpty())
                         .map(ParameterValue::getName)
                         .collect(Collectors.toCollection(() -> new HashSet<>())); // Make sure the set is serializable.
             } else {


### PR DESCRIPTION
Prevents empty value password parameters from being added to the sensitive variables list in `workflow-api`

https://github.com/jenkinsci/workflow-cps-plugin/pull/401 does the same thing, but that is more of a general hardening of `workflow-cps`