### PR TITLE
Vendored Guava should not use reflection

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ChainingListenableFuture.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ChainingListenableFuture.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.workflow.support.concurrent;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -208,7 +207,7 @@ class ChainingListenableFuture<I, O>
               ChainingListenableFuture.this.outputFuture = null;
             }
           }
-        }, Futures.newExecutorService());
+        }, MoreExecutors.directExecutor());
     } catch (UndeclaredThrowableException e) {
       // Set the cause of the exception as this future's exception
       setException(e.getCause());

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ChainingListenableFuture.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ChainingListenableFuture.java
@@ -29,6 +29,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * in a {@code UndeclaredThrowableException} so that this class can get
  * access to the cause.
  */
+@Deprecated
 class ChainingListenableFuture<I, O>
     extends AbstractFuture<O> implements Runnable {
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/DirectExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/DirectExecutor.java
@@ -15,6 +15,8 @@
 package org.jenkinsci.plugins.workflow.support.concurrent;
 
 import com.google.common.annotations.GwtCompatible;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import java.util.concurrent.Executor;
 
 /**
@@ -22,6 +24,7 @@ import java.util.concurrent.Executor;
  * execute}.
  */
 @GwtCompatible
+@Restricted(NoExternalUse.class)
 enum DirectExecutor implements Executor {
   INSTANCE;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/DirectExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/DirectExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.jenkinsci.plugins.workflow.support.concurrent;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.concurrent.Executor;
+
+/**
+ * An {@link Executor} that runs each task in the thread that invokes {@link Executor#execute
+ * execute}.
+ */
+@GwtCompatible
+enum DirectExecutor implements Executor {
+  INSTANCE;
+
+  @Override
+  public void execute(Runnable command) {
+    command.run();
+  }
+
+  @Override
+  public String toString() {
+    return "MoreExecutors.directExecutor()";
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
@@ -25,12 +25,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
@@ -408,29 +405,6 @@ public abstract class Futures {
               }
           };
       return transform(input, wrapperFunction, executor);
-    }
-
-    /**
-     * Returns an {@link ExecutorService} to be used as a parameter in other methods.
-     * It calls {@code MoreExecutors#newDirectExecutorService} or falls back to {@code MoreExecutors#sameThreadExecutor}
-     * for compatibility with older (&lt; 18.0) versions of guava.
-     *
-     * @since TODO
-     */
-    public static ExecutorService newExecutorService() {
-        try {
-            try {
-                // Guava older than 18
-                Method method = MoreExecutors.class.getMethod("sameThreadExecutor");
-                return (ExecutorService) method.invoke(null);
-            } catch (NoSuchMethodException e) {
-                // TODO invert this to prefer the newer guava method once guava is upgrade in Jenkins core
-                Method method = MoreExecutors.class.getMethod("newDirectExecutorService");
-                return (ExecutorService) method.invoke(null);
-            }
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e ) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 
 import javax.annotation.Nullable;
@@ -70,7 +69,7 @@ public abstract class Futures {
      * Note: If the callback is slow or heavyweight, consider {@linkplain
      * #addCallback(ListenableFuture, FutureCallback, Executor) supplying an
      * executor}. If you do not supply an executor, {@code addCallback} will use
-     * {@link MoreExecutors#sameThreadExecutor sameThreadExecutor}, which carries
+     * a {@linkplain MoreExecutors#directExecutor direct executor}, which carries
      * some caveats for heavier operations. For example, the callback may run on
      * an unpredictable or undesirable thread:
      *
@@ -97,7 +96,7 @@ public abstract class Futures {
      */
     public static <V> void addCallback(ListenableFuture<V> future,
         FutureCallback<? super V> callback) {
-      addCallback(future, callback, newExecutorService());
+      addCallback(future, callback, MoreExecutors.directExecutor());
     }
 
     /**
@@ -125,7 +124,7 @@ public abstract class Futures {
      *
      * When the callback is fast and lightweight, consider {@linkplain
      * #addCallback(ListenableFuture, FutureCallback) omitting the executor} or
-     * explicitly specifying {@code sameThreadExecutor}. However, be aware of the
+     * explicitly specifying {@code directExecutor}. However, be aware of the
      * caveats documented in the link above.
      *
      * <p>For a more general interface to attach a completion listener to a
@@ -214,9 +213,9 @@ public abstract class Futures {
      * (whether the {@code Future} itself is slow or heavyweight to complete is
      * irrelevant), consider {@linkplain #transform(ListenableFuture,
      * AsyncFunction, Executor) supplying an executor}. If you do not supply an
-     * executor, {@code transform} will use {@link
-     * MoreExecutors#sameThreadExecutor sameThreadExecutor}, which carries some
-     * caveats for heavier operations. For example, the call to {@code
+     * executor, {@code transform} will use a
+     * {@linkplain MoreExecutors#directExecutor direct executor}, which carries
+     * some caveats for heavier operations. For example, the call to {@code
      * function.apply} may run on an unpredictable or undesirable thread:
      *
      * <ul>
@@ -249,7 +248,7 @@ public abstract class Futures {
      */
     public static <I, O> ListenableFuture<O> transform(ListenableFuture<I> input,
             AsyncFunction<? super I, ? extends O> function) {
-        return transform(input, function, MoreExecutors.sameThreadExecutor());
+        return transform(input, function, MoreExecutors.directExecutor());
     }
 
     /**
@@ -281,7 +280,7 @@ public abstract class Futures {
      * <p>When the execution of {@code function.apply} is fast and lightweight
      * (though the {@code Future} it returns need not meet these criteria),
      * consider {@linkplain #transform(ListenableFuture, AsyncFunction) omitting
-     * the executor} or explicitly specifying {@code sameThreadExecutor}.
+     * the executor} or explicitly specifying {@code directExecutor}.
      * However, be aware of the caveats documented in the link above.
      *
      * @param input The future to transform
@@ -320,10 +319,10 @@ public abstract class Futures {
      *
      * Note: If the transformation is slow or heavyweight, consider {@linkplain
      * #transform(ListenableFuture, Function, Executor) supplying an executor}.
-     * If you do not supply an executor, {@code transform} will use {@link
-     * MoreExecutors#sameThreadExecutor sameThreadExecutor}, which carries some
-     * caveats for heavier operations.  For example, the call to {@code
-     * function.apply} may run on an unpredictable or undesirable thread:
+     * If you do not supply an executor, {@code transform} will use an inline
+     * executor, which carries some caveats for heavier operations.  For example,
+     * the call to {@code function.apply} may run on an unpredictable or
+     * undesirable thread:
      *
      * <ul>
      * <li>If the input {@code Future} is done at the time {@code transform} is
@@ -357,7 +356,7 @@ public abstract class Futures {
      */
     public static <I, O> ListenableFuture<O> transform(ListenableFuture<I> input,
         final Function<? super I, ? extends O> function) {
-      return transform(input, function, MoreExecutors.sameThreadExecutor());
+      return transform(input, function, MoreExecutors.directExecutor());
     }
 
     /**
@@ -388,7 +387,7 @@ public abstract class Futures {
      *
      * <p>When the transformation is fast and lightweight, consider {@linkplain
      * #transform(ListenableFuture, Function) omitting the executor} or
-     * explicitly specifying {@code sameThreadExecutor}. However, be aware of the
+     * explicitly specifying {@code directExecutor}. However, be aware of the
      * caveats documented in the link above.
      *
      * @param input The future to transform
@@ -454,7 +453,7 @@ public abstract class Futures {
     public static <V> ListenableFuture<List<V>> allAsList(
         ListenableFuture<? extends V>... futures) {
       return new ListFuture<V>(ImmutableList.copyOf(futures), true,
-          newExecutorService());
+          MoreExecutors.directExecutor());
     }
 
     /**
@@ -477,6 +476,6 @@ public abstract class Futures {
     public static <V> ListenableFuture<List<V>> allAsList(
         Iterable<? extends ListenableFuture<? extends V>> futures) {
       return new ListFuture<V>(ImmutableList.copyOf(futures), true,
-          newExecutorService());
+          MoreExecutors.directExecutor());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
@@ -67,19 +67,26 @@ public abstract class Futures {
      *       }
      *     });}</pre>
      *
-     * <p>Note: This overload of {@code addCallback} is designed for cases in
-     * which the callback is fast and lightweight, as the method does not accept
-     * an {@code Executor} in which to perform the the work. For heavier
-     * callbacks, this overload carries some caveats: First, the thread that the
-     * callback runs in depends on whether the input {@code Future} is done at the
-     * time {@code addCallback} is called and on whether the input {@code Future}
-     * is ever cancelled. In particular, {@code addCallback} may execute the
-     * callback in the thread that calls {@code addCallback} or {@code
-     * Future.cancel}. Second, callbacks may run in an internal thread of the
-     * system responsible for the input {@code Future}, such as an RPC network
-     * thread. Finally, during the execution of a {@code newExecutorService}
-     * callback, all other registered but unexecuted listeners are prevented from
-     * running, even if those listeners are to run in other executors.
+     * Note: If the callback is slow or heavyweight, consider {@linkplain
+     * #addCallback(ListenableFuture, FutureCallback, Executor) supplying an
+     * executor}. If you do not supply an executor, {@code addCallback} will use
+     * {@link MoreExecutors#sameThreadExecutor sameThreadExecutor}, which carries
+     * some caveats for heavier operations. For example, the callback may run on
+     * an unpredictable or undesirable thread:
+     *
+     * <ul>
+     * <li>If the input {@code Future} is done at the time {@code addCallback} is
+     * called, {@code addCallback} will execute the callback inline.
+     * <li>If the input {@code Future} is not yet done, {@code addCallback} will
+     * schedule the callback to be run by the thread that completes the input
+     * {@code Future}, which may be an internal system thread such as an RPC
+     * network thread.
+     * </ul>
+     *
+     * Also note that, regardless of which thread executes the callback, all
+     * other registered but unexecuted listeners are prevented from running
+     * during its execution, even if those listeners are to run in other
+     * executors.
      *
      * <p>For a more general interface to attach a completion listener to a
      * {@code Future}, see {@link ListenableFuture#addListener addListener}.
@@ -116,20 +123,10 @@ public abstract class Futures {
      *       }
      *     });}</pre>
      *
-     * When the callback is fast and lightweight consider {@linkplain
-     * Futures#addCallback(ListenableFuture, FutureCallback) the other overload}
-     * or explicit use of {@link #newExecutorService()}.
-     * For heavier callbacks, this choice carries some
-     * caveats: First, the thread that the callback runs in depends on whether
-     * the input {@code Future} is done at the time {@code addCallback} is called
-     * and on whether the input {@code Future} is ever cancelled. In particular,
-     * {@code addCallback} may execute the callback in the thread that calls
-     * {@code addCallback} or {@code Future.cancel}. Second, callbacks may run in
-     * an internal thread of the system responsible for the input {@code Future},
-     * such as an RPC network thread. Finally, during the execution of a {@code
-     * newExecutorService} callback, all other registered but unexecuted
-     * listeners are prevented from running, even if those listeners are to run
-     * in other executors.
+     * When the callback is fast and lightweight, consider {@linkplain
+     * #addCallback(ListenableFuture, FutureCallback) omitting the executor} or
+     * explicitly specifying {@code sameThreadExecutor}. However, be aware of the
+     * caveats documented in the link above.
      *
      * <p>For a more general interface to attach a completion listener to a
      * {@code Future}, see {@link ListenableFuture#addListener addListener}.
@@ -213,20 +210,28 @@ public abstract class Futures {
      *       transform(rowKeyFuture, queryFunction);
      * }</pre>
      *
-     * <p>Note: This overload of {@code transform} is designed for cases in which
-     * the work of creating the derived {@code Future} is fast and lightweight,
-     * as the method does not accept an {@code Executor} in which to perform the
-     * the work. (The created {@code Future} itself need not complete quickly.)
-     * For heavier operations, this overload carries some caveats: First, the
-     * thread that {@code function.apply} runs in depends on whether the input
-     * {@code Future} is done at the time {@code transform} is called. In
-     * particular, if called late, {@code transform} will run the operation in
-     * the thread that called {@code transform}.  Second, {@code function.apply}
-     * may run in an internal thread of the system responsible for the input
-     * {@code Future}, such as an RPC network thread.  Finally, during the
-     * execution of a {@code sameThreadExecutor} {@code function.apply}, all
-     * other registered but unexecuted listeners are prevented from running, even
-     * if those listeners are to run in other executors.
+     * Note: If the derived {@code Future} is slow or heavyweight to create
+     * (whether the {@code Future} itself is slow or heavyweight to complete is
+     * irrelevant), consider {@linkplain #transform(ListenableFuture,
+     * AsyncFunction, Executor) supplying an executor}. If you do not supply an
+     * executor, {@code transform} will use {@link
+     * MoreExecutors#sameThreadExecutor sameThreadExecutor}, which carries some
+     * caveats for heavier operations. For example, the call to {@code
+     * function.apply} may run on an unpredictable or undesirable thread:
+     *
+     * <ul>
+     * <li>If the input {@code Future} is done at the time {@code transform} is
+     * called, {@code transform} will call {@code function.apply} inline.
+     * <li>If the input {@code Future} is not yet done, {@code transform} will
+     * schedule {@code function.apply} to be run by the thread that completes the
+     * input {@code Future}, which may be an internal system thread such as an
+     * RPC network thread.
+     * </ul>
+     *
+     * Also note that, regardless of which thread executes {@code
+     * function.apply}, all other registered but unexecuted listeners are
+     * prevented from running during its execution, even if those listeners are
+     * to run in other executors.
      *
      * <p>The returned {@code Future} attempts to keep its cancellation state in
      * sync with that of the input future and that of the future returned by the
@@ -273,20 +278,11 @@ public abstract class Futures {
      * cancelled, the returned {@code Future} will receive a callback in which it
      * will attempt to cancel itself.
      *
-     * <p>Note: For cases in which the work of creating the derived future is
-     * fast and lightweight, consider {@linkplain
-     * Futures#transform(ListenableFuture, Function) the other overload} or
-     * explicit use of {@code sameThreadExecutor}. For heavier derivations, this
-     * choice carries some caveats: First, the thread that {@code function.apply}
-     * runs in depends on whether the input {@code Future} is done at the time
-     * {@code transform} is called. In particular, if called late, {@code
-     * transform} will run the operation in the thread that called {@code
-     * transform}.  Second, {@code function.apply} may run in an internal thread
-     * of the system responsible for the input {@code Future}, such as an RPC
-     * network thread.  Finally, during the execution of a {@code
-     * sameThreadExecutor} {@code function.apply}, all other registered but
-     * unexecuted listeners are prevented from running, even if those listeners
-     * are to run in other executors.
+     * <p>When the execution of {@code function.apply} is fast and lightweight
+     * (though the {@code Future} it returns need not meet these criteria),
+     * consider {@linkplain #transform(ListenableFuture, AsyncFunction) omitting
+     * the executor} or explicitly specifying {@code sameThreadExecutor}.
+     * However, be aware of the caveats documented in the link above.
      *
      * @param input The future to transform
      * @param function A function to transform the result of the input future
@@ -322,19 +318,26 @@ public abstract class Futures {
      *       transform(queryFuture, rowsFunction);
      * }</pre>
      *
-     * <p>Note: This overload of {@code transform} is designed for cases in which
-     * the transformation is fast and lightweight, as the method does not accept
-     * an {@code Executor} in which to perform the the work. For heavier
-     * transformations, this overload carries some caveats: First, the thread
-     * that the transformation runs in depends on whether the input {@code
-     * Future} is done at the time {@code transform} is called. In particular, if
-     * called late, {@code transform} will perform the transformation in the
-     * thread that called {@code transform}. Second, transformations may run in
-     * an internal thread of the system responsible for the input {@code Future},
-     * such as an RPC network thread. Finally, during the execution of a {@code
-     * newExecutorService} transformation, all other registered but unexecuted
-     * listeners are prevented from running, even if those listeners are to run
-     * in other executors.
+     * Note: If the transformation is slow or heavyweight, consider {@linkplain
+     * #transform(ListenableFuture, Function, Executor) supplying an executor}.
+     * If you do not supply an executor, {@code transform} will use {@link
+     * MoreExecutors#sameThreadExecutor sameThreadExecutor}, which carries some
+     * caveats for heavier operations.  For example, the call to {@code
+     * function.apply} may run on an unpredictable or undesirable thread:
+     *
+     * <ul>
+     * <li>If the input {@code Future} is done at the time {@code transform} is
+     * called, {@code transform} will call {@code function.apply} inline.
+     * <li>If the input {@code Future} is not yet done, {@code transform} will
+     * schedule {@code function.apply} to be run by the thread that completes the
+     * input {@code Future}, which may be an internal system thread such as an
+     * RPC network thread.
+     * </ul>
+     *
+     * Also note that, regardless of which thread executes {@code
+     * function.apply}, all other registered but unexecuted listeners are
+     * prevented from running during its execution, even if those listeners are
+     * to run in other executors.
      *
      * <p>The returned {@code Future} attempts to keep its cancellation state in
      * sync with that of the input future. That is, if the returned {@code Future}
@@ -383,20 +386,10 @@ public abstract class Futures {
      * <p>An example use of this method is to convert a serializable object
      * returned from an RPC into a POJO.
      *
-     * <p>Note: For cases in which the transformation is fast and lightweight,
-     * consider {@linkplain Futures#transform(ListenableFuture, Function) the
-     * other overload} or explicit use of {@link
-     * #newExecutorService}. For heavier transformations, this
-     * choice carries some caveats: First, the thread that the transformation
-     * runs in depends on whether the input {@code Future} is done at the time
-     * {@code transform} is called. In particular, if called late, {@code
-     * transform} will perform the transformation in the thread that called
-     * {@code transform}.  Second, transformations may run in an internal thread
-     * of the system responsible for the input {@code Future}, such as an RPC
-     * network thread.  Finally, during the execution of a {@code
-     * newExecutorService} transformation, all other registered but unexecuted
-     * listeners are prevented from running, even if those listeners are to run
-     * in other executors.
+     * <p>When the transformation is fast and lightweight, consider {@linkplain
+     * #transform(ListenableFuture, Function) omitting the executor} or
+     * explicitly specifying {@code sameThreadExecutor}. However, be aware of the
+     * caveats documented in the link above.
      *
      * @param input The future to transform
      * @param function A Function to transform the results of the provided future

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/Futures.java
@@ -41,6 +41,7 @@ import static com.google.common.util.concurrent.Uninterruptibles.getUninterrupti
  *
  * @author Guava
  */
+@Deprecated
 public abstract class Futures {
     /**
      * Registers separate success and failure callbacks to be run when the {@code

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ListFuture.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ListFuture.java
@@ -36,6 +36,7 @@ import static com.google.common.util.concurrent.Uninterruptibles.getUninterrupti
    * each component future to fill out the value in the List when that future
    * completes.
    */
+@Deprecated
 class ListFuture<V> extends AbstractFuture<List<V>> {
     ImmutableList<? extends ListenableFuture<? extends V>> futures;
     final boolean allMustSucceed;

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ListFuture.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/ListFuture.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -75,7 +74,7 @@ class ListFuture<V> extends AbstractFuture<List<V>> {
           // Let go of the memory held by other futures
           ListFuture.this.futures = null;
         }
-      }, Futures.newExecutorService());
+      }, MoreExecutors.directExecutor());
 
       // Now begin the "real" initialization.
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/MoreExecutors.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/MoreExecutors.java
@@ -15,6 +15,8 @@
 package org.jenkinsci.plugins.workflow.support.concurrent;
 
 import com.google.common.annotations.GwtCompatible;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -30,6 +32,7 @@ import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
  * @since 3.0
  */
 @GwtCompatible(emulated = true)
+@Restricted(NoExternalUse.class)
 public final class MoreExecutors {
   private MoreExecutors() {}
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/MoreExecutors.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/MoreExecutors.java
@@ -57,7 +57,7 @@ public final class MoreExecutors {
    *       tasks -- even tasks that are not themselves {@code directExecutor} tasks.
    *   <li>If many such tasks are chained together (such as with {@code
    *       future.transform(...).transform(...).transform(...)....}), they may overflow the stack.
-   *       (In simple cases, callers can avoid this by registering all tasks with the same {@link
+   *       (In simple cases, callers can avoid this by registering all tasks with the same {@code
    *       MoreExecutors#newSequentialExecutor} wrapper around {@code directExecutor()}. More
    *       complex cases may require using thread pools or making deeper changes.)
    * </ul>
@@ -76,7 +76,7 @@ public final class MoreExecutors {
    * }
    * }</pre>
    *
-   * <p>This should be preferred to {@link #newDirectExecutorService()} because implementing the
+   * <p>This should be preferred to {@code #newDirectExecutorService()} because implementing the
    * {@link ExecutorService} subinterface necessitates significant performance overhead.
    *
    *

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/MoreExecutors.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/concurrent/MoreExecutors.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.jenkinsci.plugins.workflow.support.concurrent;
+
+import com.google.common.annotations.GwtCompatible;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+
+/**
+ * Factory and utility methods for {@link java.util.concurrent.Executor}, {@link ExecutorService},
+ * and {@link java.util.concurrent.ThreadFactory}.
+ *
+ * @author Eric Fellheimer
+ * @author Kyle Littlefield
+ * @author Justin Mahoney
+ * @since 3.0
+ */
+@GwtCompatible(emulated = true)
+public final class MoreExecutors {
+  private MoreExecutors() {}
+
+  /**
+   * Returns an {@link Executor} that runs each task in the thread that invokes {@link
+   * Executor#execute execute}, as in {@code ThreadPoolExecutor.CallerRunsPolicy}.
+   *
+   * <p>This executor is appropriate for tasks that are lightweight and not deeply chained.
+   * Inappropriate {@code directExecutor} usage can cause problems, and these problems can be
+   * difficult to reproduce because they depend on timing. For example:
+   *
+   * <ul>
+   *   <li>A call like {@code future.transform(function, directExecutor())} may execute the function
+   *       immediately in the thread that is calling {@code transform}. (This specific case happens
+   *       if the future is already completed.) If {@code transform} call was made from a UI thread
+   *       or other latency-sensitive thread, a heavyweight function can harm responsiveness.
+   *   <li>If the task will be executed later, consider which thread will trigger the execution --
+   *       since that thread will execute the task inline. If the thread is a shared system thread
+   *       like an RPC network thread, a heavyweight task can stall progress of the whole system or
+   *       even deadlock it.
+   *   <li>If many tasks will be triggered by the same event, one heavyweight task may delay other
+   *       tasks -- even tasks that are not themselves {@code directExecutor} tasks.
+   *   <li>If many such tasks are chained together (such as with {@code
+   *       future.transform(...).transform(...).transform(...)....}), they may overflow the stack.
+   *       (In simple cases, callers can avoid this by registering all tasks with the same {@link
+   *       MoreExecutors#newSequentialExecutor} wrapper around {@code directExecutor()}. More
+   *       complex cases may require using thread pools or making deeper changes.)
+   * </ul>
+   *
+   * Additionally, beware of executing tasks with {@code directExecutor} while holding a lock. Since
+   * the task you submit to the executor (or any other arbitrary work the executor does) may do slow
+   * work or acquire other locks, you risk deadlocks.
+   *
+   * <p>This instance is equivalent to:
+   *
+   * <pre>{@code
+   * final class DirectExecutor implements Executor {
+   *   public void execute(Runnable r) {
+   *     r.run();
+   *   }
+   * }
+   * }</pre>
+   *
+   * <p>This should be preferred to {@link #newDirectExecutorService()} because implementing the
+   * {@link ExecutorService} subinterface necessitates significant performance overhead.
+   *
+   *
+   * @since 18.0
+   */
+  public static Executor directExecutor() {
+    return DirectExecutor.INSTANCE;
+  }
+}


### PR DESCRIPTION
Simpler and reflection-free alternative to #114 (CC @timja).

`org.jenkinsci.plugins.workflow.support.concurrent.ChainingListenableFuture`, `org.jenkinsci.plugins.workflow.support.concurrent.Futures`, and `org.jenkinsci.plugins.workflow.support.concurrent.ListFuture` are private copies of Guava classes specifically for use by Pipeline (in particular, they are being used by `workflow-cps`, `workflow-cps-checkpoint`, `workflow-job`, and `workflow-support`). The reasoning for making private copies is given in Kohsuke's comment:

> Mostly copied after Guava's `Futures`, because that one is still marked as beta and is subject to change.

The whole point of vendoring these classes was to insulate Pipeline from Guava API changes. The problem here is that Kohsuke just didn't go far enough with this design, since what he copied and pasted itself depended on APIs marked as beta and subject to change. This change just completes what Kohsuke started by vendoring the rest of the Guava related code in the call hierarchy. I also cherry-picked some fixes and updates from upstream to get the vendored version up-to-date.

This is all consistent with the original design of vendoring the relevant `Futures` functionality for use in Pipeline. But one might also ask if this design still makes sense in a Guava 30+ world where these APIs are no longer beta. Of course it doesn't, so once Jenkins core is on a newer version of Guava and the baseline has been updated in all the Pipeline plugins, these vendored classes can be removed. Accordingly I've marked the existing ones as `@Deprecated` and the new ones as `@Restricted(DoNotUse.class)` in anticipation of this eventual removal.

I'll test this with `workflow-cps` and `workflow-job` which use the vendored classes. It would be great if a CloudBees employee could test this change with `workflow-cps-checkpoint` which I don't have access to.