### PR TITLE
Migrate from `RestartableJenkinsRule` to `JenkinsSessionRule`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/SerializationSecurityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/SerializationSecurityTest.java
@@ -41,19 +41,19 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.For;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 @Issue("SECURITY-699")
 public class SerializationSecurityTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
 
-    @Rule public RestartableJenkinsRule rr = new RestartableJenkinsRule();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
     
     /** @see SerializableClass#callWriteObject */
     @For(RiverWriter.class)
-    @Test public void writeObjectChecksSandbox() {
-        rr.then(r -> {
+    @Test public void writeObjectChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack {\n" +
@@ -70,8 +70,8 @@ public class SerializationSecurityTest {
 
     /** @see SerializableClass#callWriteReplace */
     @For(RiverWriter.class)
-    @Test public void writeReplaceChecksSandbox() {
-        rr.then(r -> {
+    @Test public void writeReplaceChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack {\n" +
@@ -89,8 +89,8 @@ public class SerializationSecurityTest {
 
     /** @see RiverMarshaller#doWriteObject */
     @For(RiverWriter.class)
-    @Test public void writeExternalChecksSandbox() {
-        rr.then(r -> {
+    @Test public void writeExternalChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack implements Externalizable {\n" +
@@ -108,8 +108,8 @@ public class SerializationSecurityTest {
 
     /** @see SerializableClass#callReadObject */
     @For(RiverReader.class)
-    @Test public void readObjectChecksSandbox() {
-        rr.then(r -> {
+    @Test public void readObjectChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack {\n" +
@@ -122,7 +122,7 @@ public class SerializationSecurityTest {
                 "echo(/should not still have $hack/)", true));
             SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             SemaphoreStep.success("wait/1", null);
             safe(r, r.waitForCompletion(r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1)));
         });
@@ -131,8 +131,8 @@ public class SerializationSecurityTest {
 
     /** @see SerializableClass#callReadResolve */
     @For(RiverReader.class)
-    @Test public void readResolveChecksSandbox() {
-        rr.then(r -> {
+    @Test public void readResolveChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack {\n" +
@@ -145,7 +145,7 @@ public class SerializationSecurityTest {
                 "echo(/should not still have $hack/)", true));
             SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             SemaphoreStep.success("wait/1", null);
             safe(r, r.waitForCompletion(r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1)));
         });
@@ -153,8 +153,8 @@ public class SerializationSecurityTest {
 
     /** @see RiverUnmarshaller#doReadNewObject */
     @For(RiverReader.class)
-    @Test public void readExternalChecksSandbox() {
-        rr.then(r -> {
+    @Test public void readExternalChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack implements Externalizable {\n" +
@@ -168,7 +168,7 @@ public class SerializationSecurityTest {
                 "echo(/should not still have $hack/)", true));
             SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             SemaphoreStep.success("wait/1", null);
             safe(r, r.waitForCompletion(r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1)));
         });
@@ -176,8 +176,8 @@ public class SerializationSecurityTest {
 
     /** @see SerializableClass#callNoArgConstructor */
     @For(RiverReader.class)
-    @Test public void externalizableNoArgConstructorChecksSandbox() {
-        rr.then(r -> {
+    @Test public void externalizableNoArgConstructorChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack implements Externalizable {\n" +
@@ -193,7 +193,7 @@ public class SerializationSecurityTest {
                 "echo(/should not still have $hack/)", true));
             SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             SemaphoreStep.success("wait/1", null);
             safe(r, r.waitForCompletion(r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1)));
         });
@@ -204,8 +204,8 @@ public class SerializationSecurityTest {
      * @see SerializableClass#callObjectInputConstructor
      */
     @For(RiverReader.class)
-    @Test public void externalizableObjectInputConstructorChecksSandbox() {
-        rr.then(r -> {
+    @Test public void externalizableObjectInputConstructorChecksSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Hack implements Externalizable {\n" +
@@ -221,15 +221,15 @@ public class SerializationSecurityTest {
                 "echo(/should not still have $hack/)", true));
             SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             SemaphoreStep.success("wait/1", null);
             safe(r, r.waitForCompletion(r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1)));
         });
     }
 
     @Ignore("does not currently work (fails on `new Replacer`), since CpsWhitelist & GroovyClassLoaderWhitelist are not in .all()")
-    @Test public void harmlessCallsPassSandbox() {
-        rr.then(r -> {
+    @Test public void harmlessCallsPassSandbox() throws Throwable {
+        sessions.then(r -> {
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "class Fine {\n" +
@@ -247,7 +247,7 @@ public class SerializationSecurityTest {
                 "echo(/but we do have $fine/)", true));
             SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).waitForStart());
         });
-        rr.then(r -> {
+        sessions.then(r -> {
             SemaphoreStep.success("wait/1", null);
             r.assertLogContains("but we do have something safe", r.assertBuildStatusSuccess(r.waitForCompletion(r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1))));
         });

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -49,20 +49,19 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockFolder;
-import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsSessionRule;
 
 @Issue("JENKINS-26834")
 public class RunWrapperTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
-    @Rule public RestartableJenkinsRule r = new RestartableJenkinsRule();
+    @Rule public JenkinsSessionRule sessions = new JenkinsSessionRule();
     @Rule public GitSampleRepoRule sampleRepo1 = new GitSampleRepoRule();
     @Rule public GitSampleRepoRule sampleRepo2 = new GitSampleRepoRule();
 
-    @Test public void historyAndPickling() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void historyAndPickling() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "def b0 = currentBuild\n" +
                     "for (b = b0; b != null; b = b.previousBuild) {\n" +
@@ -70,54 +69,48 @@ public class RunWrapperTest {
                     "  echo \"number=${b.number} result=${b.result}\"\n" +
                     "}", true));
                 SemaphoreStep.success("basics/1", null);
-                WorkflowRun b1 = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-                r.j.assertLogContains("number=1 result=null", b1);
+                WorkflowRun b1 = j.buildAndAssertSuccess(p);
+                j.assertLogContains("number=1 result=null", b1);
                 WorkflowRun b2 = p.scheduleBuild2(0).getStartCondition().get();
                 SemaphoreStep.success("basics/2", null);
                 SemaphoreStep.waitForStart("basics/3", b2);
-                r.j.waitForMessage("number=2 result=null", b2);
-                r.j.assertLogNotContains("number=1", b2);
-            }
+                j.waitForMessage("number=2 result=null", b2);
+                j.assertLogNotContains("number=1", b2);
         });
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+        sessions.then(j -> {
+                WorkflowJob p = j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 WorkflowRun b2 = p.getBuildByNumber(2);
                 SemaphoreStep.success("basics/3", b2);
-                r.j.assertBuildStatusSuccess(r.j.waitForCompletion(b2));
-                r.j.assertLogContains("number=1 result=SUCCESS", b2);
-            }
+                j.assertBuildStatusSuccess(j.waitForCompletion(b2));
+                j.assertLogContains("number=1 result=SUCCESS", b2);
         });
     }
 
-    @Test public void updateSelf() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.jenkins.createProject(WorkflowJob.class, "p");
+    @Test public void updateSelf() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "currentBuild.result = 'UNSTABLE'\n" +
                     "currentBuild.description = 'manipulated'\n" +
                     "currentBuild.displayName = 'special'\n" +
                     "def pb = currentBuild.previousBuild; if (pb != null) {pb.displayName = 'verboten'}", true));
-                WorkflowRun b1 = r.j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
+                WorkflowRun b1 = j.buildAndAssertStatus(Result.UNSTABLE, p);
                 assertEquals("manipulated", b1.getDescription());
                 assertEquals("special", b1.getDisplayName());
-                WorkflowRun b2 = r.j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+                WorkflowRun b2 = j.buildAndAssertStatus(Result.FAILURE, p);
                 assertEquals(SecurityException.class, b2.getExecution().getCauseOfFailure().getClass());
                 assertEquals("manipulated", b2.getDescription());
                 assertEquals("special", b2.getDisplayName());
                 assertEquals("special", b1.getDisplayName());
-            }
         });
     }
 
     @Issue("JENKINS-30412")
-    @Test public void getChangeSets() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
+    @Test public void getChangeSets() throws Throwable {
+        sessions.then(j -> {
                 sampleRepo1.init();
                 sampleRepo2.init();
-                WorkflowJob p = r.j.jenkins.createProject(WorkflowJob.class, "p");
+                WorkflowJob p = j.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(
                     "node {dir('1') {git($/" + sampleRepo1 + "/$)}; dir('2') {git($/" + sampleRepo2 + "/$)}}\n" +
                     "echo(/changeSets: ${summarize currentBuild}/)\n" +
@@ -130,11 +123,11 @@ public class RunWrapperTest {
                     "    }.join(', ')\n" +
                     "  }.join(' & ')\n" +
                     "}", true));
-                r.j.assertLogContains("changeSets: ", r.j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+                j.assertLogContains("changeSets: ", j.buildAndAssertSuccess(p));
                 sampleRepo1.write("onefile", "stuff");
                 sampleRepo1.git("add", "onefile");
                 sampleRepo1.git("commit", "--message=stuff");
-                assertThat(JenkinsRule.getLog(r.j.assertBuildStatusSuccess(p.scheduleBuild2(0))), containsRegexp(
+                assertThat(JenkinsRule.getLog(j.buildAndAssertSuccess(p)), containsRegexp(
                     "changeSets: kind=git; entries=[a-f0-9]{40} by .+ ~ .+ on .+: stuff: add onefile"));
                 sampleRepo1.write("onefile", "more stuff");
                 sampleRepo1.write("anotherfile", "stuff");
@@ -146,56 +139,50 @@ public class RunWrapperTest {
                 sampleRepo2.write("elsewhere", "stuff");
                 sampleRepo2.git("add", "elsewhere");
                 sampleRepo2.git("commit", "--message=second repo");
-                assertThat(JenkinsRule.getLog(r.j.assertBuildStatusSuccess(p.scheduleBuild2(0))), containsRegexp(
+                assertThat(JenkinsRule.getLog(j.buildAndAssertSuccess(p)), containsRegexp(
                     "changeSets: kind=git; entries=[a-f0-9]{40} by .+ ~ .+ on .+: more stuff: (edit onefile; add anotherfile|add anotherfile; edit onefile), " +
                     "[a-f0-9]{40} by .+ ~ .+ on .+: amended: edit onefile & " +
                     "kind=git; entries=[a-f0-9]{40} by .+ ~ .+ on .+: second repo: add elsewhere"));
-            }
         });
     }
 
     @Issue("JENKINS-37366")
-    @Test public void projectInfoFromCurrentBuild() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                MockFolder folder = r.j.createFolder("this-folder");
+    @Test public void projectInfoFromCurrentBuild() throws Throwable {
+        sessions.then(j -> {
+                MockFolder folder = j.createFolder("this-folder");
                 WorkflowJob p = folder.createProject(WorkflowJob.class, "this-job");
                 p.setDefinition(new CpsFlowDefinition(
                         "echo \"currentBuild.fullDisplayName='${currentBuild.fullDisplayName}'\"\n" +
                         "echo \"currentBuild.projectName='${currentBuild.projectName}'\"\n" +
                         "echo \"currentBuild.fullProjectName='${currentBuild.fullProjectName}'\"\n", true));
-                WorkflowRun b = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+                WorkflowRun b = j.buildAndAssertSuccess(p);
                 { // TODO mojibake until https://github.com/jenkinsci/workflow-job-plugin/pull/89 is released and can be consumed as a test dependency; expect this-folder » this-job #1
-                    r.j.assertLogContains("currentBuild.fullDisplayName='this-folder", b);
-                    r.j.assertLogContains("this-job #1'", b);
+                    j.assertLogContains("currentBuild.fullDisplayName='this-folder", b);
+                    j.assertLogContains("this-job #1'", b);
                 }
-                r.j.assertLogContains("currentBuild.projectName='this-job'", b);
-                r.j.assertLogContains("currentBuild.fullProjectName='this-folder/this-job'", b);
-            }
+                j.assertLogContains("currentBuild.projectName='this-job'", b);
+                j.assertLogContains("currentBuild.fullProjectName='this-folder/this-job'", b);
         });
     }
 
     @Issue("JENKINS-42952")
-    @Test public void duration() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.createProject(WorkflowJob.class, "this-job");
+    @Test public void duration() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "this-job");
                 p.setDefinition(new CpsFlowDefinition(
                         "echo \"currentBuild.duration='${currentBuild.duration}'\"\n" +
                                 "echo \"currentBuild.durationString='${currentBuild.durationString}'\"\n", true));
-                WorkflowRun b = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-                r.j.assertLogNotContains("currentBuild.duration='0'", b);
-                r.j.assertLogNotContains("currentBuild.durationString='" + Messages.Run_NotStartedYet() + "'", b);
-            }
+                WorkflowRun b = j.buildAndAssertSuccess(p);
+                j.assertLogNotContains("currentBuild.duration='0'", b);
+                j.assertLogNotContains("currentBuild.durationString='" + Messages.Run_NotStartedYet() + "'", b);
         });
     }
 
 
     @Issue("JENKINS-37366")
-    @Test public void getCurrentResult() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                MockFolder folder = r.j.createFolder("this-folder");
+    @Test public void getCurrentResult() throws Throwable {
+        sessions.then(j -> {
+                MockFolder folder = j.createFolder("this-folder");
                 WorkflowJob p = folder.createProject(WorkflowJob.class, "current-result-job");
                 p.setDefinition(new CpsFlowDefinition(
                         "echo \"initial currentBuild.currentResult='${currentBuild.currentResult}'\"\n" +
@@ -204,48 +191,43 @@ public class RunWrapperTest {
                         "echo \"resultIsBetterOrEqualTo FAILURE: ${currentBuild.resultIsBetterOrEqualTo('FAILURE')}\"\n" +
                         "echo \"resultIsWorseOrEqualTo SUCCESS: ${currentBuild.resultIsWorseOrEqualTo('SUCCESS')}\"\n",
                         true));
-                WorkflowRun b = r.j.assertBuildStatus(Result.UNSTABLE, p.scheduleBuild2(0).get());
-                r.j.assertLogContains("initial currentBuild.currentResult='" + Result.SUCCESS.toString() + "'", b);
-                r.j.assertLogContains("final currentBuild.currentResult='" + Result.UNSTABLE.toString() + "'", b);
-                r.j.assertLogContains("resultIsBetterOrEqualTo FAILURE: true", b);
-                r.j.assertLogContains("resultIsWorseOrEqualTo SUCCESS: true", b);
-            }
+                WorkflowRun b = j.buildAndAssertStatus(Result.UNSTABLE, p);
+                j.assertLogContains("initial currentBuild.currentResult='" + Result.SUCCESS.toString() + "'", b);
+                j.assertLogContains("final currentBuild.currentResult='" + Result.UNSTABLE.toString() + "'", b);
+                j.assertLogContains("resultIsBetterOrEqualTo FAILURE: true", b);
+                j.assertLogContains("resultIsWorseOrEqualTo SUCCESS: true", b);
         });
     }
 
     @Issue("JENKINS-36528")
-    @Test public void freestyleEnvVars() {
-        r.addStep(new Statement() {
-            @Override public void evaluate() throws Throwable {
-                WorkflowJob p = r.j.createProject(WorkflowJob.class, "pipeline-job");
-                FreeStyleProject f = r.j.createProject(FreeStyleProject.class, "freestyle-job");
+    @Test public void freestyleEnvVars() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob p = j.createProject(WorkflowJob.class, "pipeline-job");
+                FreeStyleProject f = j.createProject(FreeStyleProject.class, "freestyle-job");
                 f.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("param", "default")));
                 p.setDefinition(new CpsFlowDefinition(
                         "def b = build(job: 'freestyle-job', parameters: [string(name: 'param', value: 'something')])\n" +
                                 "echo \"b.buildVariables.BUILD_TAG='${b.buildVariables.BUILD_TAG}'\"\n" +
                                 "echo \"b.buildVariables.param='${b.buildVariables.param}'\"\n", true));
-                WorkflowRun b = r.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-                r.j.assertLogContains("b.buildVariables.BUILD_TAG='jenkins-freestyle-job-1'", b);
-                r.j.assertLogContains("b.buildVariables.param='something'", b);
-            }
+                WorkflowRun b = j.buildAndAssertSuccess(p);
+                j.assertLogContains("b.buildVariables.BUILD_TAG='jenkins-freestyle-job-1'", b);
+                j.assertLogContains("b.buildVariables.param='something'", b);
         });
     }
 
     @Test
     @Issue("JENKINS-54227")
-    public void buildCauseTest() {
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-            WorkflowJob job = r.j.createProject(WorkflowJob.class, "test");
+    public void buildCauseTest() throws Throwable {
+        sessions.then(j -> {
+            WorkflowJob job = j.createProject(WorkflowJob.class, "test");
             // test with a single build cause
             job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses().toString()\n"
                                                     + "assert currentBuild.getBuildCauses().size() == 1\n"
                                                     + "assert currentBuild.getBuildCauses()[0].userId == 'tester'\n",
                                                     true));
-            WorkflowRun run = r.j.assertBuildStatusSuccess(job.scheduleBuild2(0, new CauseAction(new Cause
+            WorkflowRun run = j.assertBuildStatusSuccess(job.scheduleBuild2(0, new CauseAction(new Cause
                     .UserIdCause("tester"))));
-            r.j.assertLogContains("[{\"_class\":\"hudson.model.Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\",\"userId\":\"tester\",\"userName\":\"anonymous\"}]",run);
+            j.assertLogContains("[{\"_class\":\"hudson.model.Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\",\"userId\":\"tester\",\"userName\":\"anonymous\"}]",run);
 
             // test with mutiple build causes
             job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses().toString()\n"
@@ -254,9 +236,9 @@ public class RunWrapperTest {
                                                     + "assert currentBuild.getBuildCauses()[1].userId == 'tester'\n",
                                                     true));
 
-            run = r.j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
+            run = j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
                 .RemoteCause("upstream.host","this is a note"), new Cause.UserIdCause("tester"))));
-            r.j.assertLogContains("[{\"_class\":\"hudson.model.Cause$RemoteCause\",\"shortDescription\":\"Started by "
+            j.assertLogContains("[{\"_class\":\"hudson.model.Cause$RemoteCause\",\"shortDescription\":\"Started by "
                                   + "remote host upstream.host with note: this is a note\",\"addr\":\"upstream"
                                   + ".host\",\"note\":\"this is a note\"},{\"_class\":\"hudson.model"
                                   + ".Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\","
@@ -271,41 +253,37 @@ public class RunWrapperTest {
                                                     + ".Cause$UserIdCause')[0].userId == 'tester2'\n",
                                                     true));
 
-            run = r.j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
+            run = j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
                     .RemoteCause("upstream.host","this is a note"), new Cause.UserIdCause("tester2"))));
-            r.j.assertLogContains("[{\"_class\":\"hudson.model"
+            j.assertLogContains("[{\"_class\":\"hudson.model"
                                   + ".Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\","
                                   + "\"userId\":\"tester2\",\"userName\":\"anonymous\"}]", run);
 
-            }
         });
 
     }
 
     @Issue("JENKINS-31576")
     @Test
-    public void upstreamBuilds() {
-        r.addStep(new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                WorkflowJob first = r.j.createProject(WorkflowJob.class, "first-job");
-                WorkflowJob second = r.j.createProject(WorkflowJob.class, "second-job");
-                WorkflowJob third = r.j.createProject(WorkflowJob.class, "third-job");
+    public void upstreamBuilds() throws Throwable {
+        sessions.then(j -> {
+                WorkflowJob first = j.createProject(WorkflowJob.class, "first-job");
+                WorkflowJob second = j.createProject(WorkflowJob.class, "second-job");
+                WorkflowJob third = j.createProject(WorkflowJob.class, "third-job");
                 first.setDefinition(new CpsFlowDefinition("build job: 'second-job'\n", true));
                 second.setDefinition(new CpsFlowDefinition("build job: 'third-job'\n", true));
                 third.setDefinition(new CpsFlowDefinition("currentBuild.upstreamBuilds?.each { b ->\n" +
                         "  echo \"b: ${b.getFullDisplayName()}\"\n" +
                         "}\n", true));
 
-                WorkflowRun firstRun = r.j.buildAndAssertSuccess(first);
+                WorkflowRun firstRun = j.buildAndAssertSuccess(first);
                 WorkflowRun secondRun = second.getBuildByNumber(1);
-                r.j.assertBuildStatusSuccess(secondRun);
+                j.assertBuildStatusSuccess(secondRun);
                 WorkflowRun thirdRun = third.getBuildByNumber(1);
-                r.j.assertBuildStatusSuccess(thirdRun);
+                j.assertBuildStatusSuccess(thirdRun);
 
-                r.j.assertLogContains("b: " + firstRun.getFullDisplayName(), thirdRun);
-                r.j.assertLogContains("b: " + secondRun.getFullDisplayName(), thirdRun);
-            }
+                j.assertLogContains("b: " + firstRun.getFullDisplayName(), thirdRun);
+                j.assertLogContains("b: " + secondRun.getFullDisplayName(), thirdRun);
         });
     }
 


### PR DESCRIPTION
We seem to be generally preferring `JenkinsSessionRule` to `RestartableJenkinsRule`. The main benefit to `JenkinsSessionRule` is that `#then` runs immediately, so it plays nicely with things like `@After.`