### PR TITLE
Improve durability of `SURVIVABLE_NONATOMIC` while retaining the skipping of `fsync(2)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
   ~ THE SOFTWARE.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.15</version>
+        <version>4.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,7 +64,7 @@
     <properties>
         <revision>3.9</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.300-rc31329.23a941f5b44f</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/5599 -->
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
@@ -75,8 +75,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>21</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>887.vae9c8ac09ff7</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/storage/BulkFlowNodeStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/storage/BulkFlowNodeStorage.java
@@ -78,6 +78,7 @@ public class BulkFlowNodeStorage extends FlowNodeStorage {
         this.dir = dir;
         this.nodes = null;
         this.setAvoidAtomicWrite(true);
+        this.setAvoidForce(true);
     }
 
     /** Loads the nodes listing, lazily - so loading the {@link FlowExecution} doesn't trigger a more complex load. */
@@ -165,7 +166,7 @@ public class BulkFlowNodeStorage extends FlowNodeStorage {
             if (!dir.exists()) {
                 IOUtils.mkdirs(dir);
             }
-            PipelineIOUtils.writeByXStream(nodes, getStoreFile(), XSTREAM, !this.isAvoidAtomicWrite());
+            PipelineIOUtils.writeByXStream(nodes, getStoreFile(), XSTREAM, !this.isAvoidAtomicWrite(), !this.isAvoidForce());
 
             isModified = false;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/storage/FlowNodeStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/storage/FlowNodeStorage.java
@@ -29,6 +29,8 @@ import org.jenkinsci.plugins.workflow.graph.FlowActionStorage;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -46,6 +48,7 @@ import javax.annotation.Nonnull;
 public abstract class FlowNodeStorage implements FlowActionStorage {
     // Set up as "avoid" because an unset field will default to false when deserializing and not explicitly set.
     private transient boolean avoidAtomicWrite = false;
+    private transient boolean avoidForce = false;
 
     /** If true, we use non-atomic write of XML files for this storage. See {@link hudson.util.AtomicFileWriter}. */
     public boolean isAvoidAtomicWrite() {
@@ -56,6 +59,22 @@ public abstract class FlowNodeStorage implements FlowActionStorage {
      */
     public void setAvoidAtomicWrite(boolean avoidAtomicWrite){
         this.avoidAtomicWrite = avoidAtomicWrite;
+    }
+
+    /**
+     * If true, avoid the use of {@link FileChannel#force} (i.e., {@code fsync} or {@code
+     * FlushFileBuffers}) for XML files for this storage.
+     */
+    public boolean isAvoidForce() {
+        return avoidForce;
+    }
+
+    /**
+     * Set whether or not we should avoid using {@link FileChannel#force} (i.e., {@code fsync} or
+     * {@code FlushFileBuffers}) for node files.
+     */
+    public void setAvoidForce(boolean avoidForce) {
+        this.avoidForce = avoidForce;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/storage/SimpleXStreamFlowNodeStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/storage/SimpleXStreamFlowNodeStorage.java
@@ -179,7 +179,7 @@ public class SimpleXStreamFlowNodeStorage extends FlowNodeStorage {
 
     private void writeNode(FlowNode node, List<Action> actions) throws IOException {
         nodeCache.put(node.getId(), node);
-        PipelineIOUtils.writeByXStream(new Tag(node, actions), getNodeFile(node.getId()), XSTREAM, !this.isAvoidAtomicWrite());
+        PipelineIOUtils.writeByXStream(new Tag(node, actions), getNodeFile(node.getId()), XSTREAM, !this.isAvoidAtomicWrite(), !this.isAvoidForce());
     }
 
     /**


### PR DESCRIPTION
Not yet ready for review. Filing just to get an incremental build.

See [JENKINS-66001](https://issues.jenkins.io/browse/JENKINS-66001). Downstream of jenkinsci/jenkins#5599. Relates to jenkinsci/workflow-api-plugin#163. Part 3 of a 5-part series to make Pipeline's `SURVIVABLE_NONATOMIC` mode behave [as advertised in the documentation](https://www.jenkins.io/doc/book/pipeline/scaling-pipeline/#what-am-i-giving-up-with-this-durability-setting-trade-off) (parts 4 through 5 will be in `workflow-cps` and `workflow-job` respectively).