### PR TITLE
`WorkspaceRunAction` optimization

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/WorkspaceRunAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/WorkspaceRunAction.java
@@ -51,9 +51,11 @@ public final class WorkspaceRunAction implements Action {
 
     private static final Logger LOGGER = Logger.getLogger(WorkspaceRunAction.class.getName());
 
+    private final FlowExecutionOwner.Executable build;
     public final FlowExecutionOwner owner;
 
-    WorkspaceRunAction(FlowExecutionOwner owner) {
+    WorkspaceRunAction(FlowExecutionOwner.Executable build, FlowExecutionOwner owner) {
+        this.build = build;
         this.owner = owner;
     }
 
@@ -66,6 +68,9 @@ public final class WorkspaceRunAction implements Action {
     }
 
     @Override public String getUrlName() {
+        if (build instanceof AccessControlled && !((AccessControlled) build).hasPermission(Item.WORKSPACE)) {
+            return null;
+        }
         return "ws";
     }
 
@@ -95,14 +100,11 @@ public final class WorkspaceRunAction implements Action {
         }
 
         @Override public Collection<? extends Action> createFor(FlowExecutionOwner.Executable target) {
-            if (target instanceof AccessControlled && !((AccessControlled) target).hasPermission(Item.WORKSPACE)) {
-                return Collections.emptySet();
-            }
             FlowExecutionOwner owner = target.asFlowExecutionOwner();
             if (owner == null) {
                 return Collections.emptySet();
             }
-            return Collections.singleton(new WorkspaceRunAction(owner));
+            return Collections.singleton(new WorkspaceRunAction(target, owner));
         }
 
     }


### PR DESCRIPTION
Noticed in a thread dump:

```
"Handling GET /blue/rest/organizations/jenkins/pipelines/…/runs/…/tests/ from … state=RUNNABLE cpu=93%
    at org.acegisecurity.GrantedAuthority.fromSpring(GrantedAuthority.java:56)
    at org.acegisecurity.GrantedAuthority$$Lambda$….apply(Unknown Source)
    at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
    at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:546)
    at java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
    at java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:505)
    at org.acegisecurity.GrantedAuthority.fromSpring(GrantedAuthority.java:67)
    at org.acegisecurity.providers.UsernamePasswordAuthenticationToken.getAuthorities(UsernamePasswordAuthenticationToken.java:57)
    at nectar.plugins.rbac.groups.GroupContainerACL._hasPermission(GroupContainerACL.java:92)
    at nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:76)
    at hudson.security.ACL.hasPermission2(ACL.java:177)
    at hudson.security.ACL.hasPermission(ACL.java:137)
    at hudson.security.AccessControlled.hasPermission(AccessControlled.java:64)
    at org.jenkinsci.plugins.workflow.support.actions.WorkspaceRunAction$Factory.createFor(WorkspaceRunAction.java:98)
    at org.jenkinsci.plugins.workflow.support.actions.WorkspaceRunAction$Factory.createFor(WorkspaceRunAction.java:91)
    at hudson.model.Actionable.createFor(Actionable.java:114)
    at hudson.model.Actionable.getAction(Actionable.java:335)
    at hudson.tasks.test.TestResult.getPreviousResult(TestResult.java:144)
    at hudson.tasks.junit.TestResult.getPreviousResult(TestResult.java:253)
    at hudson.tasks.junit.SuiteResult.getPreviousResult(SuiteResult.java:416)
    at hudson.tasks.junit.CaseResult.getPreviousResult(CaseResult.java:527)
    at hudson.tasks.junit.CaseResult.getStatus(CaseResult.java:722)
    at io.jenkins.blueocean.service.embedded.rest.junit.BlueJUnitTestResult.getTestState(BlueJUnitTestResult.java:65)
    at io.jenkins.blueocean.rest.factory.BlueTestResultFactory$Result.of(BlueTestResultFactory.java:82)
    at io.jenkins.blueocean.service.embedded.rest.junit.BlueJUnitTestResult$FactoryImpl.getBlueTestResults(BlueJUnitTestResult.java:145)
    at io.jenkins.blueocean.rest.factory.BlueTestResultFactory.resolve(BlueTestResultFactory.java:124)
    at io.jenkins.blueocean.service.embedded.rest.BlueTestResultContainerImpl.resolve(BlueTestResultContainerImpl.java:38)
    at io.jenkins.blueocean.service.embedded.rest.BlueTestResultContainerImpl.iterator(BlueTestResultContainerImpl.java:61)
    at io.jenkins.blueocean.rest.model.Container.iterator(Container.java:39)
    at io.jenkins.blueocean.rest.pageable.PagedResponse$Processor$1.generateResponse(PagedResponse.java:57)
    at …
```

There is no reason to do access control checks eagerly in `createFor`. Suffices to wait unless and until the action is actually accessed. Note that https://github.com/jenkinsci/workflow-support-plugin/blob/7355059e0faa8a04b1cc1b5ef941b521a784002c/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/WorkspaceRunAction/index.jelly#L29 already does the corresponding check in the GUI.
