### PR TITLE
Allow access to workspaces location through api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ work
 
 # macOS
 .DS_Store
+
+.classpath
+.settings
+.project


### PR DESCRIPTION
Allows access to information about workspaces through the API. No need to parse HTML output anymore.

Exports WorkspaceRunAction class and new value object with workspace information.


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
