### PR TITLE
Buffer writes on the Java side in RiverWriter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverWriter.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverWriter.java
@@ -222,7 +222,9 @@ public class RiverWriter implements Closeable {
 
         private void writeBuffer() throws IOException {
             buffer.flip();
-            channel.write(buffer);
+            if (buffer.limit() > 0) {
+                channel.write(buffer);
+            }
             buffer.clear();
         }
 


### PR DESCRIPTION
I saw a stack trace indicating that #129 may have introduced performance issues in some cases due to lack of write buffering on the Java side. `FileChannel.write` directly calls OS APIs, so while there is still potentially an OS-side buffer, it might be slower than buffering writes on the Java side.

Untested, and I have not attempted to validate the performance impact.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
