### PR TITLE
Use CSS animation for progressive console logging

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogActionImpl/index.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
         <j:when test="${it.parent.isRunning()}">
           <pre id="out" />
           <div id="spinner">
-            <img src="${imagesURL}/spinner.gif" alt="" />
+            <l:progressAnimation/>
           </div>
          <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner" startOffset="${offset}" />
         </j:when>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction/index.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
         <j:when test="${it.node.running}">
           <pre id="out" />
           <div id="spinner">
-            <img src="${imagesURL}/spinner.gif" alt="" />
+            <l:progressAnimation/>
           </div>
          <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner" startOffset="${offset}" />
         </j:when>


### PR DESCRIPTION
The CSS animation and jelly tag were added in 2.320 to core:

https://user-images.githubusercontent.com/13383509/158278950-b6680f6d-ed65-4ffd-b5a3-d857629434ff.mp4

The change proposed replaced the spinner.gif and utilizes the modern status dots for progressive rendering.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue