### PR TITLE
Don't show workspace icon if the user lacks permission to access it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/WorkspaceRunAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/WorkspaceRunAction.java
@@ -59,19 +59,20 @@ public final class WorkspaceRunAction implements Action {
         this.owner = owner;
     }
 
+    private boolean hasNoWorkspacePermission() {
+        return (build instanceof AccessControlled && !((AccessControlled) build).hasPermission(Item.WORKSPACE));
+    }
+
     @Override public String getIconFileName() {
-        return "folder.png";
+        return hasNoWorkspacePermission() ? null : "folder.png";
     }
 
     @Override public String getDisplayName() {
-        return Messages.workspaces();
+        return hasNoWorkspacePermission() ? null : Messages.workspaces();
     }
 
     @Override public String getUrlName() {
-        if (build instanceof AccessControlled && !((AccessControlled) build).hasPermission(Item.WORKSPACE)) {
-            return null;
-        }
-        return "ws";
+        return hasNoWorkspacePermission() ? null : "ws";
     }
 
     public List<WorkspaceActionImpl> getActions() {


### PR DESCRIPTION
The change proposed hides the `Workspaces` button if the user lacks permission to access it.

The current behavior of the icon being shown can be seen on ci.jenkins.io, for example: https://ci.jenkins.io/job/Core/job/jenkins/job/master/lastSuccessfulBuild/flowGraphTable/

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
