### PR TITLE
Fix flakiness by synchronising the State

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -104,14 +104,14 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
     public static void success(String k, Object returnValue) {
         State s = State.get();
         synchronized (s) {
-            if (s.contexts.containsKey(k)) {
-                System.err.println("Unblocking " + k + " as success");
-                getContext(s, k).onSuccess(returnValue);
-            } else {
+            if (!s.contexts.containsKey(k)) {
                 System.err.println("Planning to unblock " + k + " as success");
                 s.returnValues.put(k, returnValue);
+                return;
             }
         }
+        System.err.println("Unblocking " + k + " as success");
+        getContext(s, k).onSuccess(returnValue);
     }
 
     /** Marks the step as having failed; or, if not yet started, makes it do so synchronously when started. */
@@ -122,14 +122,14 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
     public static void failure(String k, Throwable error) {
         State s = State.get();
         synchronized (s) {
-            if (s.contexts.containsKey(k)) {
-                System.err.println("Unblocking " + k + " as failure");
-                getContext(s, k).onFailure(error);
-            } else {
+            if (!s.contexts.containsKey(k)) {
                 System.err.println("Planning to unblock " + k + " as failure");
                 s.errors.put(k, error);
+                return;
             }
         }
+        System.err.println("Unblocking " + k + " as failure");
+        getContext(s, k).onFailure(error);
     }
     
     public StepContext getContext() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -103,12 +103,14 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
 
     public static void success(String k, Object returnValue) {
         State s = State.get();
-        if (s.contexts.containsKey(k)) {
-            System.err.println("Unblocking " + k + " as success");
-            getContext(s, k).onSuccess(returnValue);
-        } else {
-            System.err.println("Planning to unblock " + k + " as success");
-            s.returnValues.put(k, returnValue);
+        synchronized (s) {
+            if (s.contexts.containsKey(k)) {
+                System.err.println("Unblocking " + k + " as success");
+                getContext(s, k).onSuccess(returnValue);
+            } else {
+                System.err.println("Planning to unblock " + k + " as success");
+                s.returnValues.put(k, returnValue);
+            }
         }
     }
 
@@ -119,12 +121,14 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
 
     public static void failure(String k, Throwable error) {
         State s = State.get();
-        if (s.contexts.containsKey(k)) {
-            System.err.println("Unblocking " + k + " as failure");
-            getContext(s, k).onFailure(error);
-        } else {
-            System.err.println("Planning to unblock " + k + " as failure");
-            s.errors.put(k, error);
+        synchronized (s) {
+            if (s.contexts.containsKey(k)) {
+                System.err.println("Unblocking " + k + " as failure");
+                getContext(s, k).onFailure(error);
+            } else {
+                System.err.println("Planning to unblock " + k + " as failure");
+                s.errors.put(k, error);
+            }
         }
     }
     


### PR DESCRIPTION
Description:

Cloudbees CI reported a flake in 
[org.jenkinsci.plugins.workflow.support.steps.StageStepTest.serializability](https://github.com/jenkinsci/pipeline-stage-step-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/support/steps/StageStepTest.java#L173-L200)

Error Log:
[stderr.txt](https://github.com/jenkinsci/workflow-support-plugin/files/9150162/stderr.txt)

How to reproduce:
I wasn't managed to reproduce it locally without code changes, but if we add `TimeUnit.MILLISECONDS.sleep(200);` before this [line](https://github.com/jenkinsci/workflow-support-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java#L110) the StageStepTest.serializability started to flake regularly.


Assumption:
My assumption that there is a deadlock possibility.


Solution:
As a solution I want to suggest to synchronize the State local variable (the same synchronisation mechanism is used [here](https://github.com/jenkinsci/workflow-support-plugin/blob/master/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java#L141)) 





<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
