### PR TITLE
Fixing synchronization in `SemaphoreStep`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -24,7 +24,6 @@
 
 package org.jenkinsci.plugins.workflow.test.steps;
 
-import com.google.inject.Inject;
 import hudson.Extension;
 import hudson.model.Run;
 import java.io.File;
@@ -36,34 +35,40 @@ import java.util.Map;
 import java.util.Set;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Step that blocks until signaled.
- * Starts running and waits for {@link #success(Object)} or {@link #failure(Throwable)} to be called, if they have not been already.
+ * Starts running and waits for {@link #success(String, Object)} or {@link #failure(String, Throwable)} to be called, if they have not been already.
  */
-public final class SemaphoreStep extends AbstractStepImpl implements Serializable {
+public final class SemaphoreStep extends Step implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(SemaphoreStep.class.getName());
 
     /** State of semaphore steps within one Jenkins home and thus (possibly restarting) test. */
     private static final class State {
-        private static final Map<File,State> states = new HashMap<File,State>();
+        private static final Map<File,State> states = new HashMap<>();
         static synchronized State get() {
             File home = Jenkins.get().getRootDir();
             State state = states.get(home);
             if (state == null) {
+                LOGGER.info(() -> "Initializing state in " + home);
                 state = new State();
                 states.put(home, state);
             }
             return state;
         }
         private State() {}
-        private final Map<String,Integer> iota = new HashMap<String,Integer>();
+        private final Map<String,Integer> iota = new HashMap<>();
         synchronized int allocateNumber(String id) {
             Integer old = iota.get(id);
             if (old == null) {
@@ -74,10 +79,10 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
             return number;
         }
         /** map from {@link #k} to serial form of {@link StepContext} */
-        final Map<String,String> contexts = new HashMap<String,String>();
-        final Map<String,Object> returnValues = new HashMap<String,Object>();
-        final Map<String,Throwable> errors = new HashMap<String,Throwable>();
-        final Set<String> started = new HashSet<String>();
+        final Map<String,String> contexts = new HashMap<>();
+        final Map<String,Object> returnValues = new HashMap<>();
+        final Map<String,Throwable> errors = new HashMap<>();
+        final Set<String> started = new HashSet<>();
     }
 
     private final String id;
@@ -96,47 +101,61 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
         return id + "/" + number;
     }
 
-    /** Marks the step as having successfully completed; or, if not yet started, makes it do so synchronously when started. */
+    /**@deprecated use {@link #success(String, Object)} */
+    @Deprecated
     public void success(Object returnValue) {
         success(k(), returnValue);
     }
 
+    /** Marks the step as having successfully completed; or, if not yet started, makes it do so synchronously when started. */
     public static void success(String k, Object returnValue) {
         State s = State.get();
+        StepContext c;
         synchronized (s) {
             if (!s.contexts.containsKey(k)) {
-                System.err.println("Planning to unblock " + k + " as success");
+                LOGGER.info(() -> "Planning to unblock " + k + " as success");
                 s.returnValues.put(k, returnValue);
                 return;
             }
+            c = getContext(s, k);
         }
-        System.err.println("Unblocking " + k + " as success");
-        getContext(s, k).onSuccess(returnValue);
+        LOGGER.info(() -> "Unblocking " + k + " as success");
+        c.onSuccess(returnValue);
     }
 
-    /** Marks the step as having failed; or, if not yet started, makes it do so synchronously when started. */
+    /** @deprecated use {@link #failure(String, Throwable)} */
+    @Deprecated
     public void failure(Throwable error) {
         failure(k(), error);
     }
 
+    /** Marks the step as having failed; or, if not yet started, makes it do so synchronously when started. */
     public static void failure(String k, Throwable error) {
         State s = State.get();
+        StepContext c;
         synchronized (s) {
             if (!s.contexts.containsKey(k)) {
-                System.err.println("Planning to unblock " + k + " as failure");
+                LOGGER.info(() -> "Planning to unblock " + k + " as failure");
                 s.errors.put(k, error);
                 return;
             }
+            c = getContext(s, k);
         }
-        System.err.println("Unblocking " + k + " as failure");
-        getContext(s, k).onFailure(error);
+        LOGGER.info(() -> "Unblocking " + k + " as failure");
+        c.onFailure(error);
     }
-    
+
+    /** @deprecated should not be needed */
+    @Deprecated
     public StepContext getContext() {
-        return getContext(State.get(), k());
+        State s = State.get();
+        synchronized (s) {
+            return getContext(s, k());
+        }
     }
 
     private static StepContext getContext(State s, String k) {
+        assert Thread.holdsLock(s);
         return (StepContext) Jenkins.XSTREAM.fromXML(s.contexts.get(k));
     }
 
@@ -147,29 +166,50 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
                 if (b != null && !b.isBuilding()) {
                     throw new AssertionError(JenkinsRule.getLog(b));
                 }
-                s.wait(1000);
+                s.wait(100);
             }
         }
     }
 
+    @Override public StepExecution start(StepContext context) throws Exception {
+        return new Execution(context, k());
+    }
+
     public static class Execution extends AbstractStepExecutionImpl {
 
-        @Inject(optional=true) private SemaphoreStep step;
-        private String k;
+        private final String k;
+
+        Execution(StepContext context, String k) {
+            super(context);
+            this.k = k;
+        }
 
         @Override public boolean start() throws Exception {
             State s = State.get();
-            k = step.k();
-            boolean sync = true;
-            if (s.returnValues.containsKey(k)) {
-                System.err.println("Immediately running " + k);
-                getContext().onSuccess(s.returnValues.get(k));
-            } else if (s.errors.containsKey(k)) {
-                System.err.println("Immediately failing " + k);
-                getContext().onFailure(s.errors.get(k));
+            Object returnValue = null;
+            Throwable error = null;
+            boolean success = false, failure = false, sync = true;
+            synchronized (s) {
+                if (s.returnValues.containsKey(k)) {
+                    success = true;
+                    returnValue = s.returnValues.get(k);
+                } else if (s.errors.containsKey(k)) {
+                    failure = true;
+                    error = s.errors.get(k);
+                }
+            }
+            if (success) {
+                LOGGER.info(() -> "Immediately running " + k);
+                getContext().onSuccess(returnValue);
+            } else if (failure) {
+                LOGGER.info(() -> "Immediately failing " + k);
+                getContext().onFailure(error);
             } else {
-                System.err.println("Blocking " + k);
-                s.contexts.put(k, Jenkins.XSTREAM.toXML(getContext()));
+                LOGGER.info(() -> "Blocking " + k);
+                String c = Jenkins.XSTREAM.toXML(getContext());
+                synchronized (s) {
+                    s.contexts.put(k, c);
+                }
                 sync = false;
             }
             synchronized (s) {
@@ -181,23 +221,25 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
 
         @Override public void stop(Throwable cause) throws Exception {
             State s = State.get();
-            s.contexts.remove(k);
+            synchronized (s) {
+                s.contexts.remove(k);
+            }
+            LOGGER.log(Level.INFO, cause, () -> "Stopping " + k);
             super.stop(cause);
         }
 
         @Override public String getStatus() {
-            return State.get().contexts.containsKey(k) ? "waiting on " + k : "finished " + k;
+            State s = State.get();
+            synchronized (s) {
+                return s.contexts.containsKey(k) ? "waiting on " + k : "finished " + k;
+            }
         }
 
         private static final long serialVersionUID = 1L;
 
     }
 
-    @Extension public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
-
-        public DescriptorImpl() {
-            super(Execution.class);
-        }
+    @Extension public static final class DescriptorImpl extends StepDescriptor {
 
         @Override public String getFunctionName() {
             return "semaphore";
@@ -205,6 +247,10 @@ public final class SemaphoreStep extends AbstractStepImpl implements Serializabl
 
         @Override public String getDisplayName() {
             return "Test step";
+        }
+
+        @Override public Set<? extends Class<?>> getRequiredContext() {
+            return Set.of();
         }
 
     }


### PR DESCRIPTION
#188 does not seem to have been complete; various `HashMap`-valued fields in `State` were accessed without consistent locking.

Motivated by frequent flakes in `SCMRetrieverTest.selfTestLibraries` (from `pipeline-groovy-lib`) in PCT. The test would time out waiting for one of the branch builds to complete; log messages _Blocking…_ indicated that the step had been started on the right string, but then later the log would show _Planning to unblock…_ rather than _Unblocking…_, as if `contexts` did not contain the string which had been added. I was able to reproduce such a failure locally after updating the core & BOM to newest 2.414.x and running the test about ten times in a row. My hypothesis is that unsynchronized access corrupted the `HashMap`.
