### PR TITLE
`TracingRiverMarshallerFactory` to diagnose `StackOverflowError` deserializing `program.dat`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverReaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/pickles/serialization/RiverReaderTest.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.pickles.serialization;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+import hudson.model.Result;
+import java.util.logging.Level;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsSessionRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+public final class RiverReaderTest {
+
+    @Rule public final JenkinsSessionRule rr = new JenkinsSessionRule();
+    @Rule public final LoggerRule logging = new LoggerRule().record(RiverReader.class, Level.FINE).capture(2000);
+    @ClassRule public static final BuildWatcher bw = new BuildWatcher();
+
+    @Test public void stackOverflow() throws Throwable {
+        rr.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("class R {Object f}; def x = new R(); for (int i = 0; i < 1000; i++) {def y = new R(); y.f = x; x = y}; semaphore 'wait'", true));
+            SemaphoreStep.waitForStart("wait/1", p.scheduleBuild2(0).getStartCondition().get());
+        });
+        rr.then(r -> {
+            WorkflowRun b = r.jenkins.getItemByFullName("p", WorkflowJob.class).getBuildByNumber(1);
+            SemaphoreStep.success("wait/1", null);
+            r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
+            r.assertLogContains("java.lang.StackOverflowError", b);
+            r.assertLogContains("at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject", b);
+            assertThat(logging.getMessages(), hasItem("StackOverflowError trace:                                            R"));
+        });
+    }
+
+}


### PR DESCRIPTION
The test reproduces a stack trace very similar to what was observed in a Jenkins controller which was unable to resume a particular pipeline:

```
…
at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader$TracingRiverMarshallerFactory$1.doReadNewObject(RiverReader.java:391)
at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:298)
at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:246)
at org.jboss.marshalling.river.RiverUnmarshaller.readFields(RiverUnmarshaller.java:1918)
at org.jboss.marshalling.river.RiverUnmarshaller.doInitSerializable(RiverUnmarshaller.java:1831)
at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1421)
at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverReader$TracingRiverMarshallerFactory$1.doReadNewObject(RiverReader.java:391)
…
```

I am not yet sure if the information being captured here can actually be used to diagnose the issue, but it is worth a try.
