### PR TITLE
Suppress warnings for spotbugs 4.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.76</version>
+        <version>4.77</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction.java
@@ -48,7 +48,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class) // for use from DefaultStepContext only
 public class LogStorageAction extends LogAction implements FlowNodeAction, PersistentAction {
 
-    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="TODO clean up")
     public transient FlowNode node;
 
     private LogStorageAction(FlowNode node) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/actions/LogStorageAction.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.support.actions;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.console.AnnotatedLargeText;
 import hudson.model.TaskListener;
 import java.io.IOException;
@@ -47,6 +48,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class) // for use from DefaultStepContext only
 public class LogStorageAction extends LogAction implements FlowNodeAction, PersistentAction {
 
+    @SuppressFBWarnings(value="PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification="Retain API compatibility.")
     public transient FlowNode node;
 
     private LogStorageAction(FlowNode node) {


### PR DESCRIPTION
## Suppress warnings for spotbugs 4.8.3

https://github.com/jenkinsci/plugin-pom/pull/869 or a subsequent pull request that updates to 4.8.3 will need this change in the plugin to resolve new spotbugs warnings that will be reported by spotbugs 4.8.2
and later.

Plugin pom 4.77 is likely to include that new version of spotbugs.

### Testing done

Confirmed that the spotbugs warnings are visible when using the 4.77-SNAPSHOT plugin pom before this change. With this change, the spotbugs warnings are no longer visible.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
