### PR TITLE
Save `flowNodeStore.xml` entries in order

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/support/storage/BulkFlowNodeStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/storage/BulkFlowNodeStorageTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.support.storage;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+public final class BulkFlowNodeStorageTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void orderOfEntries() throws Exception {
+        var p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("for (int i = 1; i <= 40; i++) {echo(/step #$i/)}", true));
+        var b = r.buildAndAssertSuccess(p);
+        var entryList = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new File(b.getRootDir(), "workflow-completed/flowNodeStore.xml")).getDocumentElement().getChildNodes();
+        var ids = new ArrayList<String>();
+        for (int i = 0; i < entryList.getLength(); i++) {
+            var entry = entryList.item(i);
+            if (entry.getNodeType() == Node.ELEMENT_NODE) {
+                ids.add(((Element) entry).getElementsByTagName("*").item(0).getTextContent());
+            }
+        }
+        assertThat(ids, is(IntStream.rangeClosed(2, 43).mapToObj(Integer::toString).collect(Collectors.toList())));
+    }
+
+}


### PR DESCRIPTION
After https://github.com/jenkinsci/workflow-cps-plugin/pull/807 by @dwnusbaum I started poking through large build records captured by `support-core` and was frustrated by the semi-random order of flow nodes.

Before fix:

```
java.lang.AssertionError: 

Expected: is <[2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43]>
     but: was <[22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 10, 33, 11, 34, 12, 35, 13, 36, 14, 37, 15, 38, 16, 39, 17, 18, 19, 2, 3, 4, 5, 6, 7, 8, 9, 40, 41, 42, 20, 43, 21]>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.jenkinsci.plugins.workflow.support.storage.BulkFlowNodeStorageTest.orderOfEntries(BulkFlowNodeStorageTest.java:58)
```
