### PR TITLE
Try to fix synchronization in `SemaphoreStep`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -189,6 +189,7 @@ public final class SemaphoreStep extends Step implements Serializable {
             Object returnValue = null;
             Throwable error = null;
             boolean success = false, failure = false, sync = true;
+            String c = Jenkins.XSTREAM.toXML(getContext());
             synchronized (s) {
                 if (s.returnValues.containsKey(k)) {
                     success = true;
@@ -196,6 +197,8 @@ public final class SemaphoreStep extends Step implements Serializable {
                 } else if (s.errors.containsKey(k)) {
                     failure = true;
                     error = s.errors.get(k);
+                } else {
+                    s.contexts.put(k, c);
                 }
             }
             if (success) {
@@ -206,10 +209,6 @@ public final class SemaphoreStep extends Step implements Serializable {
                 getContext().onFailure(error);
             } else {
                 LOGGER.info(() -> "Blocking " + k);
-                String c = Jenkins.XSTREAM.toXML(getContext());
-                synchronized (s) {
-                    s.contexts.put(k, c);
-                }
                 sync = false;
             }
             synchronized (s) {


### PR DESCRIPTION
Even after #235, I saw a test flake because a `semaphore` step hung forever even though `SempahoreStep.success` was called. The logs indicate an order of operations that show a bug in the existing synchronization:

```
  10.238 [id=1884]	INFO	o.j.p.w.t.s.SemaphoreStep$Execution#start: Blocking wait/1
  10.239 [id=1839]	INFO	o.j.p.w.test.steps.SemaphoreStep#success: Planning to unblock wait/1 as success
```

Here is my hypothesis as to what happened. We have two threads: Thread 1 calls `SemaphoreStep.start`. Thread 2 calls `SemaphoreStep.success`. They race for the `State` monitor. I think that thread 1 acquired the `State` monitor first and ran this entire block:

https://github.com/jenkinsci/workflow-support-plugin/blob/1e84e32f7b068c0d4713a7e18b2a68eb25048702/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java#L192-L200

Thread 2 then acquired the `State` monitor and ran this block:

https://github.com/jenkinsci/workflow-support-plugin/blob/1e84e32f7b068c0d4713a7e18b2a68eb25048702/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java#L136-L143

At this point, `s.contexts` does not contain `k`, so `Planning to unblock wait/1 as success` gets logged, and the monitor is released, but **thread 1 already checked `s.returnValues` and will never check it again**. Thread 1 in the meantime proceeded to this `synchronized` block and ran it once thread 2 released the monitor:

https://github.com/jenkinsci/workflow-support-plugin/blob/1e84e32f7b068c0d4713a7e18b2a68eb25048702/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java#L210-L212

At this point though, this does nothing. Thread 2 already ran `SemaphoreStep.success`, and the context did not exist, so it put a value in `State.returnValues`. Thread 1 had already checked `SemaphoreStep.returnValues` though, and will not check it again, so the step just hangs forever and the test times out.

CC @jgreffe
