### PR TITLE
Move `SemaphoreStep` states into a single map to try to simplify the implementation

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -189,6 +189,7 @@ public final class SemaphoreStep extends Step implements Serializable {
             Object returnValue = null;
             Throwable error = null;
             boolean success = false, failure = false, sync = true;
+            String c = Jenkins.XSTREAM.toXML(getContext());
             synchronized (s) {
                 if (s.returnValues.containsKey(k)) {
                     success = true;
@@ -196,6 +197,8 @@ public final class SemaphoreStep extends Step implements Serializable {
                 } else if (s.errors.containsKey(k)) {
                     failure = true;
                     error = s.errors.get(k);
+                } else {
+                    s.contexts.put(k, c);
                 }
             }
             if (success) {
@@ -206,10 +209,6 @@ public final class SemaphoreStep extends Step implements Serializable {
                 getContext().onFailure(error);
             } else {
                 LOGGER.info(() -> "Blocking " + k);
-                String c = Jenkins.XSTREAM.toXML(getContext());
-                synchronized (s) {
-                    s.contexts.put(k, c);
-                }
                 sync = false;
             }
             synchronized (s) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -108,14 +108,12 @@ public final class SemaphoreStep extends Step implements Serializable {
         StepContext c;
         synchronized (s) {
             KeyState keyState = s.keyStates.get(k);
-            if (keyState == null) {
+            if (!(keyState instanceof StartedState)) {
                 LOGGER.info(() -> "Planning to unblock " + k + " as success");
                 s.keyStates.put(k, new ImmediateSuccessState(returnValue));
                 return;
-            } else if (keyState instanceof StartedState) {
-                c = getContext(s, k);
             } else {
-                throw new IllegalStateException("Cannot mark " + k + " as success from state " + keyState);
+                c = getContext(s, k);
             }
         }
         LOGGER.info(() -> "Unblocking " + k + " as success");
@@ -134,14 +132,12 @@ public final class SemaphoreStep extends Step implements Serializable {
         StepContext c;
         synchronized (s) {
             Object keyState = s.keyStates.get(k);
-            if (keyState == null) {
+            if (!(keyState instanceof StartedState)) {
                 LOGGER.info(() -> "Planning to unblock " + k + " as failure");
                 s.keyStates.put(k, new ImmediateFailureState(error));
                 return;
-            } else if (keyState instanceof StartedState) {
-                c = getContext(s, k);
             } else {
-                throw new IllegalStateException("Cannot mark " + k + " as failure from state " + keyState);
+                c = getContext(s, k);
             }
         }
         LOGGER.info(() -> "Unblocking " + k + " as failure");

--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStep.java
@@ -112,9 +112,8 @@ public final class SemaphoreStep extends Step implements Serializable {
                 LOGGER.info(() -> "Planning to unblock " + k + " as success");
                 s.keyStates.put(k, new ImmediateSuccessState(returnValue));
                 return;
-            } else {
-                c = getContext(s, k);
             }
+            c = getContext(s, k);
         }
         LOGGER.info(() -> "Unblocking " + k + " as success");
         c.onSuccess(returnValue);
@@ -136,9 +135,8 @@ public final class SemaphoreStep extends Step implements Serializable {
                 LOGGER.info(() -> "Planning to unblock " + k + " as failure");
                 s.keyStates.put(k, new ImmediateFailureState(error));
                 return;
-            } else {
-                c = getContext(s, k);
             }
+            c = getContext(s, k);
         }
         LOGGER.info(() -> "Unblocking " + k + " as failure");
         c.onFailure(error);


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-support-plugin/pull/258#issuecomment-2026171643.

Personally, I feel like this is still pretty comparable to https://github.com/jenkinsci/workflow-support-plugin/pull/258 in terms of complexity. It seems a little better in terms of synchronization complexity, but the state transition complexity seems about the same or worse. The issue is that the four maps did not represent distinct non-overlapping states and so it is still not that clear what is going on in the new code. If we are purely going for simplicity, something like https://github.com/jenkinsci/workflow-support-plugin/pull/259 would be my vote, then #258, then this PR.

If we want to go with this approach, I think this PR would need a PCT run because it seems possible that is accidentally broke some typical use case.