### PR TITLE
[JENKINS-73421] Expose getExternalizableId() in RunWrapper API

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -315,8 +315,8 @@ public final class RunWrapper implements Serializable {
     }
 
     @Whitelisted
-    public String getExteralizableId() throws AbortException {
-        return build().getExternalizableId();
+    public String getExteralizableId() {
+        return externalizableId;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -314,6 +314,11 @@ public final class RunWrapper implements Serializable {
         return build().getId();
     }
 
+    @Whitelisted
+    public String getExteralizableId() throws AbortException {
+        return build().getExternalizableId();
+    }
+
     /**
      * Get environment variables defined in the build.
      *

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java
@@ -315,7 +315,7 @@ public final class RunWrapper implements Serializable {
     }
 
     @Whitelisted
-    public String getExteralizableId() {
+    public String getExternalizableId() {
         return externalizableId;
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -12,6 +12,7 @@
     <dt><code>fullProjectName</code></dt><dd>Full name of the project of this build, including folders such as <code>folder1/folder2/foo</code>.</dd>
     <dt><code>description</code></dt><dd>additional information about the build</dd>
     <dt><code>id</code></dt><dd>normally <code>number</code> as a string</dd>
+    <dt><code>externalizableId</code></dt><dd>identifier for this build from combining <code>fullProjectName</code> and <code>number</code> as <code>fullProjectName#number</code></dd>
     <dt><code>timeInMillis</code></dt><dd>time since the epoch when the build was scheduled</dd>
     <dt><code>startTimeInMillis</code></dt><dd>time since the epoch when the build started running</dd>
     <dt><code>duration</code></dt><dd>duration of the build in milliseconds</dd>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -287,6 +287,17 @@ public class RunWrapperTest {
         });
     }
 
+    @Test
+    @Issue("JENKINS-73421")
+    public void externalizableId() throws Throwable {
+        sessions.then(j -> {
+            WorkflowJob first = j.createProject(WorkflowJob.class, "first-job");
+            first.setDefinition(new CpsFlowDefinition("echo currentBuild.getExternalizableId()'\n", true));
+            WorkflowRun firstRun = j.buildAndAssertSuccess(first);
+            j.assertLogContains(firstRun.getExternalizableId(), firstRun);
+        });
+    }
+
     // Like org.hamcrest.text.MatchesPattern.matchesPattern(String) but doing a substring, not whole-string, match:
     private static Matcher<String> containsRegexp(final String rx) {
         return new SubstringMatcher("containing the regexp", false, rx) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -292,7 +292,7 @@ public class RunWrapperTest {
     public void externalizableId() throws Throwable {
         sessions.then(j -> {
             WorkflowJob first = j.createProject(WorkflowJob.class, "first-job");
-            first.setDefinition(new CpsFlowDefinition("echo currentBuild.getExternalizableId()'\n", true));
+            first.setDefinition(new CpsFlowDefinition("echo currentBuild.getExternalizableId()\n", true));
             WorkflowRun firstRun = j.buildAndAssertSuccess(first);
             j.assertLogContains(firstRun.getExternalizableId(), firstRun);
         });

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -294,7 +294,7 @@ public class RunWrapperTest {
             WorkflowJob first = j.createProject(WorkflowJob.class, "first-job");
             first.setDefinition(new CpsFlowDefinition("echo(/externalizableId=$currentBuild.externalizableId/)", true));
             WorkflowRun firstRun = j.buildAndAssertSuccess(first);
-            j.assertLogContains("externalizableId=first-job#1", firstRun);
+            j.assertLogContains("externalizableId=" + firstRun.getExternalizableId(), firstRun);
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -292,9 +292,9 @@ public class RunWrapperTest {
     public void externalizableId() throws Throwable {
         sessions.then(j -> {
             WorkflowJob first = j.createProject(WorkflowJob.class, "first-job");
-            first.setDefinition(new CpsFlowDefinition("echo currentBuild.getExternalizableId()\n", true));
+            first.setDefinition(new CpsFlowDefinition("echo(/externalizableId=$currentBuild.externalizableId/)", true));
             WorkflowRun firstRun = j.buildAndAssertSuccess(first);
-            j.assertLogContains(firstRun.getExternalizableId(), firstRun);
+            j.assertLogContains("externalizableId=first-job#1", firstRun);
         });
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Implementation for https://issues.jenkins.io/browse/JENKINS-73421.

Expose `getExteralizableId()` in `RunWrapper` API. Returns the value of the existing `externalizableId` member which is assigned the `externalizableId` of the underlying build object when the `RunWrapper` is constructed.

### Testing done
Added new unit test in `RunWrapperTest`.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
