### PR TITLE
Attempt to fix flaky test on Windows

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/test/steps/SemaphoreStepTest.java
@@ -26,6 +26,6 @@ public class SemaphoreStepTest {
 
         b.doKill();
         j.waitForMessage("Hard kill!", b);
-        j.assertBuildStatus(Result.ABORTED, future);
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(b));
     }
 }


### PR DESCRIPTION
https://ci.jenkins.io/job/Plugins/job/workflow-support-plugin/job/master/163/testReport/junit/org.jenkinsci.plugins.workflow.test.steps/SemaphoreStepTest/linux_21___Build__linux_21____hardKill/ failed with

```
java.io.IOException: /home/jenkins/agent/workspace/s_workflow-support-plugin_master/target/tmp/j h14150005493844980562/jobs/p/builds/1/atomic5693325650616074372tmp
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:144)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:131)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.dispose(TemporaryDirectoryAllocator.java:99)
	at org.jvnet.hudson.test.TestEnvironment.dispose(TestEnvironment.java:84)
	at org.jvnet.hudson.test.JenkinsRule.after(JenkinsRule.java:535)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:673)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.nio.file.DirectoryNotEmptyException: /home/jenkins/agent/workspace/s_workflow-support-plugin_master/target/tmp/j h14150005493844980562/jobs/p/builds/1
	at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:289)
	at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:109)
	at java.base/java.nio.file.Files.deleteIfExists(Files.java:1191)
	at org.jvnet.hudson.test.TemporaryDirectoryAllocator.delete(TemporaryDirectoryAllocator.java:141)
	... 10 more
```