### PR TITLE
Prefer `.buildCauses` to `.getBuildCauses()`

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper/help.html
@@ -1,5 +1,5 @@
 <dl>
-    <dt><code>getBuildCauses</code></dt><dd>Returns a JSON array of build causes for the current build</dd>
+    <dt><code>buildCauses</code></dt><dd>a JSON array of causes for the build</dd>
     <dt><b>EXPERIMENTAL - MAY CHANGE</b>  <code>getBuildCauses(String causeClass)</code></dt><dd>Takes a string representing the fully qualified <code>Cause</code> class and returns a <code>JSON array</code> of build causes filtered by that type for the current build, or an empty <code>JSON array</code> if no causes of the specified type apply to the current build</code></dd>
     <dt><code>number</code></dt><dd>build number (integer)</dd>
     <dt><code>result</code></dt><dd>typically <code>SUCCESS</code>, <code>UNSTABLE</code>, or <code>FAILURE</code> (<em>may</em> be null for an ongoing build)</dd>

--- a/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapperTest.java
@@ -221,43 +221,50 @@ public class RunWrapperTest {
         sessions.then(j -> {
             WorkflowJob job = j.createProject(WorkflowJob.class, "test");
             // test with a single build cause
-            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses().toString()\n"
-                                                    + "assert currentBuild.getBuildCauses().size() == 1\n"
-                                                    + "assert currentBuild.getBuildCauses()[0].userId == 'tester'\n",
-                                                    true));
-            WorkflowRun run = j.assertBuildStatusSuccess(job.scheduleBuild2(0, new CauseAction(new Cause
-                    .UserIdCause("tester"))));
-            j.assertLogContains("[{\"_class\":\"hudson.model.Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\",\"userId\":\"tester\",\"userName\":\"anonymous\"}]",run);
+            job.setDefinition(new CpsFlowDefinition(
+                """
+                // TODO for some reason "${currentBuild.buildCauses}" prints Groovy list/map syntax, not JSON
+                echo currentBuild.buildCauses.toString()
+                assert currentBuild.buildCauses.size() == 1
+                assert currentBuild.buildCauses[0].userId == 'tester'
+                """,
+                true));
+            WorkflowRun run = j.assertBuildStatusSuccess(job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause("tester"))));
+            j.assertLogContains(
+                """
+                [{"_class":"hudson.model.Cause$UserIdCause","shortDescription":"Started by user anonymous","userId":"tester","userName":"anonymous"}]
+                """.trim(), run);
 
-            // test with mutiple build causes
-            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses().toString()\n"
-                                                    + "assert currentBuild.getBuildCauses().size() == 2\n"
-                                                    + "assert currentBuild.getBuildCauses()[0].note == 'this is a note'\n"
-                                                    + "assert currentBuild.getBuildCauses()[1].userId == 'tester'\n",
-                                                    true));
+            // test with multiple build causes
+            job.setDefinition(new CpsFlowDefinition(
+                """
+                echo currentBuild.buildCauses.toString()
+                assert currentBuild.buildCauses.size() == 2
+                assert currentBuild.buildCauses[0].note == 'this is a note'
+                assert currentBuild.buildCauses[1].userId == 'tester'
+                """,
+                true));
 
-            run = j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
-                .RemoteCause("upstream.host","this is a note"), new Cause.UserIdCause("tester"))));
-            j.assertLogContains("[{\"_class\":\"hudson.model.Cause$RemoteCause\",\"shortDescription\":\"Started by "
-                                  + "remote host upstream.host with note: this is a note\",\"addr\":\"upstream"
-                                  + ".host\",\"note\":\"this is a note\"},{\"_class\":\"hudson.model"
-                                  + ".Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\","
-                                  + "\"userId\":\"tester\",\"userName\":\"anonymous\"}]", run);
+            run = j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause.RemoteCause("upstream.host", "this is a note"), new Cause.UserIdCause("tester"))));
+            j.assertLogContains(
+                """
+                [{"_class":"hudson.model.Cause$RemoteCause","shortDescription":"Started by remote host upstream.host with note: this is a note","addr":"upstream.host","note":"this is a note"},{"_class":"hudson.model.Cause$UserIdCause","shortDescription":"Started by user anonymous","userId":"tester","userName":"anonymous"}]
+                """.trim(), run);
 
             // test filtering build causes
-            job.setDefinition(new CpsFlowDefinition("echo currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')"
-                                                    + ".toString()\n"
-                                                    + "assert currentBuild.getBuildCauses('hudson.model"
-                                                    + ".Cause$UserIdCause').size() == 1\n"
-                                                    + "assert currentBuild.getBuildCauses('hudson.model"
-                                                    + ".Cause$UserIdCause')[0].userId == 'tester2'\n",
-                                                    true));
+            job.setDefinition(new CpsFlowDefinition(
+                """
+                echo currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').toString()
+                assert currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').size() == 1
+                assert currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0].userId == 'tester2'
+                """,
+                true));
 
-            run = j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause
-                    .RemoteCause("upstream.host","this is a note"), new Cause.UserIdCause("tester2"))));
-            j.assertLogContains("[{\"_class\":\"hudson.model"
-                                  + ".Cause$UserIdCause\",\"shortDescription\":\"Started by user anonymous\","
-                                  + "\"userId\":\"tester2\",\"userName\":\"anonymous\"}]", run);
+            run = j.assertBuildStatusSuccess(job.scheduleBuild2(0,new CauseAction(new Cause.RemoteCause("upstream.host", "this is a note"), new Cause.UserIdCause("tester2"))));
+            j.assertLogContains(
+                """
+                [{"_class":"hudson.model.Cause$UserIdCause","shortDescription":"Started by user anonymous","userId":"tester2","userName":"anonymous"}]
+                """.trim(), run);
 
         });
 


### PR DESCRIPTION
Amending #78 for consistency with other properties.