### PR TITLE
Forcibly load static XStream instances during Jenkins startup to prevent a one-build memory leak

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/support/storage/BulkFlowNodeStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/storage/BulkFlowNodeStorage.java
@@ -36,6 +36,8 @@ import org.jenkinsci.plugins.workflow.support.PipelineIOUtils;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -241,6 +243,12 @@ public class BulkFlowNodeStorage extends FlowNodeStorage {
         public @NonNull List<Action> actions() {
             return actions != null ? Collections.unmodifiableList(actions) : Collections.emptyList();
         }
+    }
+
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
+    public static void loadXstream() {
+        // Ensure that the XStream instance is loaded by a controlled thread to avoid referencing a Pipeline class loader.
+        XSTREAM.getClass();
     }
 
     public static final XStream2 XSTREAM = new XStream2();

--- a/src/main/java/org/jenkinsci/plugins/workflow/support/storage/SimpleXStreamFlowNodeStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/support/storage/SimpleXStreamFlowNodeStorage.java
@@ -39,6 +39,8 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.actions.FlowNodeAction;
 import hudson.Util;
 import hudson.XmlFile;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.Action;
 import hudson.util.RobustReflectionConverter;
 import hudson.util.XStream2;
@@ -50,7 +52,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -244,6 +245,12 @@ public class SimpleXStreamFlowNodeStorage extends FlowNodeStorage {
         public @NonNull List<Action> actions() {
             return actions != null ? Collections.unmodifiableList(actions) : Collections.emptyList();
         }
+    }
+
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
+    public static void loadXstream() {
+        // Ensure that the XStream instance is loaded by a controlled thread to avoid referencing a Pipeline class loader.
+        XSTREAM.getClass();
     }
 
     public static final XStream2 XSTREAM = new XStream2();


### PR DESCRIPTION
This PR tries to address https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/199#discussion_r2377121804 by forcing `BulkFlowNodeStorage.XSTREAM` and `SimpleFlowNodeStorage.XSTREAM` to be loaded during startup via `@Initializer`.

I think we only really need this for `BulkFlowNodeStorage` due to https://github.com/jenkinsci/workflow-cps-plugin/pull/807, since with that PR, if you are using `SimpleXStreamFlowNodeStorage` (the default), the first build that completes may be the first thing to load `BulkFlowNodeStorage`, causing the one-build memory leak observed in tests in `pipeline-groovy-lib`.

I added an initializer for `SimpleFlowNodeStorage.XSTREAM` at the same time mostly just for uniformity. 

### Testing done

I tested this against https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/199 with the code referenced in https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/199#discussion_r2377121804 removed, and the test passed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
